### PR TITLE
Prefer SSH over telnet, harden the MQTT bridge, and gate OLED-only features

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,43 @@ it before exposing it more widely.
 
 ---
 
+### Use SSH, not telnet
+
+A rooted webOS TV exposes an **unauthenticated root shell on port 23**. Anyone
+on your network gets root with no credentials. The Homebrew Channel ships
+dropbear, so switching to key-based SSH is worth doing before anything else.
+
+**Order matters.** The Homebrew Channel sets a placeholder root password
+(`alpine`, a publicly known default) *unless* `/home/root/.ssh/authorized_keys`
+already exists. Enabling SSH without a key installed therefore gets you
+password login as root with a password everybody knows &mdash; no better than
+telnet. Install the key first:
+
+```bash
+# while telnet still works
+cat ~/.ssh/id_ed25519.pub | nc <tv-ip> 23   # or paste it into the shell:
+#   mkdir -p /home/root/.ssh
+#   echo 'ssh-ed25519 AAAA...' >> /home/root/.ssh/authorized_keys
+#   chmod 700 /home/root/.ssh && chmod 600 /home/root/.ssh/authorized_keys
+```
+
+Then, in order:
+
+1. Enable **SSH** in the Homebrew Channel settings.
+2. Reboot &mdash; startup.sh now sees the key, skips the `alpine` password and
+   starts dropbear.
+3. Verify `ssh root@<tv-ip>` works.
+4. **Only then** disable **telnet** in the Homebrew Channel.
+5. Reboot once more and confirm SSH still works.
+
+Do not disable telnet before step 3. If SSH does not come up you will have no
+root access, and recovery means re-rooting the TV.
+
+`deploy.sh` prefers SSH automatically and falls back to telnet, so it keeps
+working either way. Force the old path with `--telnet` if you need to.
+
+---
+
 ### Hardening the MQTT bridge
 
 Worth doing properly, because this is the part that reaches beyond the TV. The
@@ -382,6 +419,11 @@ single biggest improvement you can make.
 
 - **Root Access & Hardware**: This project runs custom software with `root` privileges on an embedded Smart TV operating system. While designed to be lightweight, read-only to rootfs, and non-destructive, the authors and contributors assume **no responsibility or liability** for any damage, bootloops, bricked devices, voided warranties, data loss, OLED panel issues, or unexpected behavior resulting from the use or misuse of this software.
 - **Power & Control Commands**: Features such as rebooting, power off, screen blanking, and Pixel Refresher scheduling issue low-level commands directly to webOS system services (`luna-send`). Ensure you understand what each command does before executing it.
+- **Non-OLED sets**: Panel hours, the Off-RS compensation cycle and the Pixel
+  Refresher only exist on OLED. On an LCD/QNED/NanoCell set these are detected
+  as unavailable and omitted &mdash; both from the dashboard and from MQTT
+  discovery &mdash; rather than reported as zero. Everything else works
+  normally.
 - **Compatibility**: Verified on a 2018 OLED65B8SLC running webOS 4.4.3
   (firmware 05.50.70). Other webOS versions are untested &mdash; the Luna calls
   and `/proc/lg` paths this relies on may differ. Reports welcome.
@@ -399,11 +441,11 @@ single biggest improvement you can make.
 To completely remove the service and boot hook from the TV:
 
 ```bash
-# Connect via telnet
-nc <tv-ip> 23
+# Connect (ssh preferred)
+ssh root@<tv-ip>        # or, if still on telnet:  nc <tv-ip> 23
 
 # Inside TV shell:
-pkill -9 -f tvweb.js
+/var/lib/tvweb/tvwebctl stop
 rm -rf /var/lib/tvweb
 rm -f /var/lib/webosbrew/init.d/50-tvweb*
 exit

--- a/README.md
+++ b/README.md
@@ -324,6 +324,58 @@ it before exposing it more widely.
 
 ---
 
+### Hardening the MQTT bridge
+
+Worth doing properly, because this is the part that reaches beyond the TV. The
+broker credentials live in `config.json` **on the TV**, and a rooted webOS set
+has an unauthenticated root shell on port 23 &mdash; so treat anything stored
+there as readable by anyone on your network. `tvweb` tightens the file to `0600`
+at startup, but that is mitigation, not a fix.
+
+The question that matters is not whether the bridge is authenticated (it is),
+but **what that credential is allowed to do**. Reuse your main Home Assistant
+MQTT user and a compromised TV can publish to any topic on the broker &mdash;
+including the ones driving your lights, locks or alarms.
+
+**1. Give the TV its own broker user with a restricted ACL.** With this in
+place, a compromised TV can only lie about its own telemetry:
+
+```conf
+# /etc/mosquitto/aclfile
+user lgtv
+topic write  lgtv/#
+topic read   lgtv/command/#
+topic write  homeassistant/+/lg_tv/#
+```
+
+The last line is deliberately narrow: unrestricted write access to
+`homeassistant/#` would let a compromised TV register arbitrary new entities
+via MQTT Discovery.
+
+**2. Encrypt the connection.** Without TLS the username and password cross your
+network in cleartext in every CONNECT packet, and a reconnect loop resends them
+every few seconds:
+
+```json
+"mqtt": { "tls": true, "port": 8883 }
+```
+
+Set `"tlsRejectUnauthorized": false` only if your broker uses a self-signed
+certificate &mdash; the traffic stays encrypted, but the broker is no longer
+authenticated, so only do it on a network you trust.
+
+**3. Consider network segmentation.** Putting the TV on its own VLAN that can
+reach only the broker is sound defence in depth. It does not replace the ACL:
+the TV must reach the broker by definition, so a stolen credential still works
+from inside the segment. The ACL is what limits the blast radius.
+
+**4. Close the root telnet.** While port 23 is an open root shell, nothing
+stored on the TV is secret and every measure above is mitigation around that
+fact. Installing openssh via the Homebrew Channel and disabling telnet is the
+single biggest improvement you can make.
+
+---
+
 ## ⚠️ Disclaimer & Safety
 
 **Use this software at your own risk.**

--- a/config.example.json
+++ b/config.example.json
@@ -8,6 +8,8 @@
     "enabled": false,
     "host": "",
     "port": 1883,
+    "tls": false,
+    "tlsRejectUnauthorized": true,
     "username": "",
     "password": "",
     "topicPrefix": "lgtv",

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -195,7 +195,12 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
 
 <section class="readouts" id="readouts"></section>
 
-<section class="panel">
+<div class="cols" id="flashrow" hidden style="margin-top:clamp(30px,5vw,52px)">
+    <div><div class="lbl">Flash wear</div><div class="v num" id="flashval">&mdash;</div></div>
+    <div><div class="lbl">Flash health</div><div class="v" id="flasheol">&mdash;</div></div>
+  </div>
+
+  <section class="panel" id="panelblock" hidden>
   <div class="lbl">OLED panel</div>
   <div class="n num" style="margin-top:12px"><span id="ph">&mdash;</span><em>hours</em></div>
   <div class="cols">
@@ -332,6 +337,9 @@ async function tick() {
     row('swap', su.toFixed(0) + '<small>%</small>', su,
         mb(d.swap.total - d.swap.free) + ' / ' + mb(d.swap.total) + ' MB zram', 70);
 
+    // Wired sets report no wlan0; hide rather than showing a blank signal.
+    q('row-net').hidden = !(d.wifi || d.net);
+    q('row-draw').hidden = !(d.power && d.power.current_ma);
     const rx = d.net ? (d.net.rx / 1024) : 0, tx = d.net ? (d.net.tx / 1024) : 0;
     row('net', rx.toFixed(0) + '<small>kB/s</small>', Math.min(100, rx / 20),
         (d.wifi ? d.wifi.level + ' dBm   ' : '') + 'up ' + tx.toFixed(0) + ' kB/s', 101);
@@ -340,12 +348,24 @@ async function tick() {
     row('draw', ma + '<small>mA</small>', Math.min(100, ma / 4),
         d.power ? ('cpu ' + d.power.cpu_ma + '   core ' + d.power.core_ma) : '', 101);
 
+    /* Capability-driven: an LCD/QNED set has no panel-hours counter, no
+       compensation cycle and no Pixel Refresher, so hide the block entirely
+       rather than showing zeros that look like measurements. */
+    const hasOled = !!(d.oled && d.oled.panel_hours !== undefined) &&
+                    !(d.capabilities && d.capabilities.oled === false);
+    q('panelblock').hidden = !hasOled;
     const o = d.oled || {};
     q('ph').textContent = (o.panel_hours || 0).toLocaleString();
     q('comp').textContent = hrs(o.hours_until_comp) + ' h';
     q('refr').textContent = hrs(o.hours_until_refresher) + ' h';
     q('rstate').textContent = o.refresher_status || '—';
     q('wear').textContent = (d.emmc && d.emmc.wear) || '—';
+    if (!hasOled && d.emmc && d.emmc.wear) {
+      // Flash health is not OLED-specific - keep it visible as its own row.
+      q('flashrow').hidden = false;
+      q('flashval').textContent = d.emmc.wear;
+      q('flasheol').textContent = d.emmc.eol || '';
+    }
 
     muted = !!d.muted;
     q('vol').textContent = muted ? 'MUTED' : d.volume;

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -1,89 +1,132 @@
 #!/bin/bash
-# Push tvweb.js to the TV and (re)start it.
 #
-# There is no SSH/scp on this TV, so this serves the file over HTTP from this
-# machine for a few seconds and has the TV wget it. Nothing is left listening.
+# Push tvweb to the TV and (re)start it.
 #
-# Usage: ./deploy.sh [tv-ip] [--persist]
+# Prefers SSH: if key-based login works, files go over scp and commands over
+# ssh. That is the recommended setup - see the Security section of the README.
+#
+# Falls back to the Homebrew Channel's root telnet on port 23 for TVs that
+# have not enabled SSH. That path serves the files over HTTP from this machine
+# for a few seconds, because telnet gives us no file transfer.
+#
+# Usage: ./deploy.sh [tv-ip] [--persist] [--telnet]
 #   --persist  also install the boot hook so it survives a reboot
+#   --telnet   force the telnet path even if SSH is available
 
 set -e
-TV="${1:-192.168.1.134}"
-[ "$1" = "--persist" ] && TV=192.168.1.134
+
+TV=""
 PERSIST=""
-for a in "$@"; do [ "$a" = "--persist" ] && PERSIST=1; done
+FORCE_TELNET=""
+for a in "$@"; do
+  case "$a" in
+    --persist) PERSIST=1 ;;
+    --telnet)  FORCE_TELNET=1 ;;
+    -*)        echo "unknown option: $a" >&2; exit 2 ;;
+    *)         TV="$a" ;;
+  esac
+done
+TV="${TV:-192.168.1.134}"
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 PORT=8771
-MYIP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null \
-       || hostname -I 2>/dev/null | awk '{print $1}')
-[ -z "$MYIP" ] && { echo "could not determine this machine's LAN IP"; exit 1; }
+SSH_OPTS=(-o BatchMode=yes -o ConnectTimeout=6 -o StrictHostKeyChecking=accept-new)
 
-HTTP_PID=""
-stop_http() {
-  if [ -n "$HTTP_PID" ]; then
-    kill "$HTTP_PID" 2>/dev/null || true
-    wait "$HTTP_PID" 2>/dev/null || true
-    HTTP_PID=""
-  fi
-  local leftover
-  leftover=$(lsof -ti :"$PORT" 2>/dev/null || true)
-  if [ -n "$leftover" ]; then
-    kill -9 $leftover 2>/dev/null || true
-  fi
+# ---------------------------------------------------------------- transport
+use_ssh() {
+  [ -n "$FORCE_TELNET" ] && return 1
+  ssh "${SSH_OPTS[@]}" "root@$TV" true >/dev/null 2>&1
 }
-trap stop_http EXIT INT TERM
+
+tvsh() {   # run stdin on the TV over the homebrew root telnet
+  { printf '\n'; sleep 1; cat; printf '\nexit\n'; sleep "${W:-8}"; } \
+    | nc -w $(( ${W:-8} + 5 )) "$TV" 23 2>/dev/null | tr -d '\r'
+}
 
 start_http() {
-  stop_http
-  python3 -m http.server "$PORT" --directory "$DIR" --bind 0.0.0.0 >/dev/null 2>&1 &
-  HTTP_PID=$!
+  ( python3 -m http.server "$PORT" --directory "$DIR" --bind 0.0.0.0 >/dev/null 2>&1 &
+    echo $! > /tmp/.tvweb_httpd )
   sleep 1
 }
+stop_http() { kill "$(cat /tmp/.tvweb_httpd 2>/dev/null)" 2>/dev/null || true; rm -f /tmp/.tvweb_httpd; }
 
-tvsh() {  # run stdin on the TV over the homebrew root telnet
-  { printf '\n'; sleep 1; cat; printf '\nexit\n'; sleep "${W:-6}"; } \
-    | nc -w $(( ${W:-6} + 5 )) "$TV" 23 2>/dev/null | LC_ALL=C tr -d '\r'
+FILES="tvweb.js tvwebctl assets/ui.html assets/fonts/Outfit.ttf assets/fonts/Manrope.ttf \
+assets/fonts/OFL-Outfit.txt assets/fonts/OFL-Manrope.txt"
+
+# ---------------------------------------------------------------- ssh path
+deploy_ssh() {
+  echo "deploying to $TV over ssh ..."
+  ssh "${SSH_OPTS[@]}" "root@$TV" 'mkdir -p /var/lib/tvweb/assets/fonts'
+  for f in $FILES; do
+    scp "${SSH_OPTS[@]}" -q "$DIR/$f" "root@$TV:/var/lib/tvweb/$f"
+  done
+  [ -f "$DIR/config.json" ] && scp "${SSH_OPTS[@]}" -q "$DIR/config.json" "root@$TV:/var/lib/tvweb/config.json"
+
+  if [ -n "$PERSIST" ]; then
+    ssh "${SSH_OPTS[@]}" "root@$TV" 'mkdir -p /var/lib/webosbrew/init.d'
+    # run-parts ignores filenames containing a dot, so the hook must not end .sh
+    scp "${SSH_OPTS[@]}" -q "$DIR/50-tvweb.sh" "root@$TV:/var/lib/webosbrew/init.d/50-tvweb"
+    ssh "${SSH_OPTS[@]}" "root@$TV" 'chmod +x /var/lib/webosbrew/init.d/50-tvweb'
+    echo "boot hook installed"
+  fi
+
+  # Restart via the on-TV control script. Doing this inline over ssh does not
+  # work: any pkill pattern matching tvweb.js also matches the remote shell,
+  # whose argv contains that path, so it kills itself first.
+  ssh "${SSH_OPTS[@]}" "root@$TV" '
+    chmod +x /var/lib/tvweb/tvwebctl
+    /var/lib/tvweb/tvwebctl restart
+    sleep 4
+    /var/lib/tvweb/tvwebctl status
+    tail -6 /var/lib/tvweb/tvweb.log'
 }
 
-echo "serving $DIR on $MYIP:$PORT ..."
-start_http
+# ---------------------------------------------------------------- telnet path
+deploy_telnet() {
+  MYIP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null \
+         || hostname -I 2>/dev/null | awk '{print $1}')
+  [ -z "$MYIP" ] && { echo "could not determine this machine's LAN IP" >&2; exit 1; }
+  echo "deploying to $TV over telnet (no ssh); serving from $MYIP:$PORT ..."
+  start_http
+  trap stop_http EXIT
 
-echo "deploying to $TV ..."
-W=14 tvsh <<TVCMDS
-mkdir -p /var/lib/tvweb
-wget -q -O /var/lib/tvweb/tvweb.js http://$MYIP:$PORT/tvweb.js && echo "fetched tvweb.js (\$(wc -c < /var/lib/tvweb/tvweb.js) bytes)"
+  # NOTE: this heredoc is unquoted so $MYIP/$PORT expand HERE. Anything that
+  # must run on the TV has to be escaped (\$f, \$(...)).
+  W=16 tvsh <<TVCMDS
 mkdir -p /var/lib/tvweb/assets/fonts
+wget -q -O /var/lib/tvweb/tvweb.js http://$MYIP:$PORT/tvweb.js && echo "tvweb.js \$(wc -c < /var/lib/tvweb/tvweb.js) bytes"
 wget -q -O /var/lib/tvweb/assets/ui.html http://$MYIP:$PORT/assets/ui.html && echo "ui.html \$(wc -c < /var/lib/tvweb/assets/ui.html) bytes"
+wget -q -O /var/lib/tvweb/tvwebctl http://$MYIP:$PORT/tvwebctl
 for f in Outfit.ttf Manrope.ttf OFL-Outfit.txt OFL-Manrope.txt; do
   wget -q -O /var/lib/tvweb/assets/fonts/\$f http://$MYIP:$PORT/assets/fonts/\$f
 done
 echo "fonts: \$(ls /var/lib/tvweb/assets/fonts | wc -l) files"
-$([ -f "$DIR/config.json" ] && echo "wget -q -O /var/lib/tvweb/config.json http://$MYIP:$PORT/config.json && echo 'fetched config.json'")
-pkill -9 -f tvweb.js 2>/dev/null || true
-sleep 1
-setsid /usr/bin/node /var/lib/tvweb/tvweb.js > /var/lib/tvweb/tvweb.log 2>&1 &
-sleep 2
-cat /var/lib/tvweb/tvweb.log
-$([ -n "$PERSIST" ] && cat <<EOF
-echo "installing boot hook ..."
-mkdir -p /var/lib/webosbrew/init.d
-wget -q -O /var/lib/webosbrew/init.d/50-tvweb http://$MYIP:$PORT/50-tvweb.sh && echo "fetched 50-tvweb"
-chmod +x /var/lib/webosbrew/init.d/50-tvweb
-ln -sf /var/lib/webosbrew/init.d/50-tvweb /var/lib/webosbrew/init.d/50-tvweb.sh
-ls -la /var/lib/webosbrew/init.d/
-echo "testing run-parts detection:"
-run-parts --test /var/lib/webosbrew/init.d
-EOF
-)
+$([ -f "$DIR/config.json" ] && echo "wget -q -O /var/lib/tvweb/config.json http://$MYIP:$PORT/config.json")
+chmod 600 /var/lib/tvweb/config.json 2>/dev/null
+$([ -n "$PERSIST" ] && echo "mkdir -p /var/lib/webosbrew/init.d && wget -q -O /var/lib/webosbrew/init.d/50-tvweb http://$MYIP:$PORT/50-tvweb.sh && chmod +x /var/lib/webosbrew/init.d/50-tvweb && echo 'boot hook installed'")
+chmod +x /var/lib/tvweb/tvwebctl
+/var/lib/tvweb/tvwebctl restart
+sleep 4
+/var/lib/tvweb/tvwebctl status
+tail -6 /var/lib/tvweb/tvweb.log
 TVCMDS
+  stop_http
+  trap - EXIT
+}
 
-stop_http
-echo "transfer server stopped"
+# ---------------------------------------------------------------- go
+if use_ssh; then
+  deploy_ssh
+else
+  if [ -z "$FORCE_TELNET" ]; then
+    echo "note: ssh to root@$TV did not work, falling back to telnet." >&2
+    echo "      Enabling SSH in the Homebrew Channel is recommended - see README." >&2
+  fi
+  deploy_telnet
+fi
 
 echo
-echo "verifying HTTP response from http://$TV:8080/api/caps ..."
-curl -s -m 5 "http://$TV:8080/api/caps" && echo "" || echo "warning: could not reach http://$TV:8080/"
-
+echo "verifying ..."
+curl -s --max-time 8 "http://$TV:8080/api/caps" || echo "(no response yet - give it a moment)"
 echo
 echo "open  http://$TV:8080/"

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -330,6 +330,35 @@ function detectDeviceInfo(cb) {
 var cachedOled = null;
 var lastOledCheck = 0;
 
+/*
+ * Not every webOS set is an OLED - LCD/QNED/NanoCell models run the same
+ * firmware but have no panel-hours counter, no Off-RS compensation and no
+ * Pixel Refresher. Detect once and omit the whole block rather than reporting
+ * a confident 0 hours, which reads as a real measurement.
+ *
+ * Two independent signals, either is sufficient:
+ *   - /var/luna/preferences/paneltype_oled, written by the platform
+ *   - a panelUsageTime that actually comes back from systemproperty
+ */
+var isOled = null;   // null = not yet determined
+
+function detectOled(cb) {
+  if (isOled !== null) return cb(isOled);
+  if (fs.existsSync('/var/luna/preferences/paneltype_oled')) {
+    isOled = true;
+    console.log('panel: OLED (paneltype_oled present)');
+    return cb(true);
+  }
+  luna('com.webos.service.tv.systemproperty/getSystemProperties',
+    { keys: ['panelUsageTime'] },
+    function (res) {
+      isOled = !!(res && res.panelUsageTime);
+      console.log('panel: ' + (isOled ? 'OLED (panelUsageTime reported)'
+                                      : 'not OLED - panel features disabled'));
+      cb(isOled);
+    });
+}
+
 function refreshOledStats(picSettings, cb) {
   var now = Date.now();
   if (cachedOled && (now - lastOledCheck < 30000)) {
@@ -545,9 +574,16 @@ function collectStats(cb) {
               logoLuminanceAdjust: pic.settings.logoLuminanceAdjust || 'off'
             };
           }
-          refreshOledStats((pic && pic.settings) ? pic.settings : null, function (oled) {
-            out.oled = oled;
-            flushStats(out);
+          detectOled(function (oledPanel) {
+            out.capabilities = { oled: oledPanel };
+            if (!oledPanel) {
+              out.oled = null;
+              return flushStats(out);
+            }
+            refreshOledStats((pic && pic.settings) ? pic.settings : null, function (oled) {
+              out.oled = oled;
+              flushStats(out);
+            });
           });
         }
       );
@@ -1672,6 +1708,7 @@ http.createServer(function (req, res) {
   console.log('tvweb listening on ' + CONFIG.host + ':' + CONFIG.port +
               '  control=' + CONFIG.allowControl + '  power=' + CONFIG.allowPower +
               '  auth=' + (CONFIG.token ? 'token' : 'none'));
+  detectOled(function () {});   // resolve and log panel type up front
 });
 
 // ---------------------------------------------------------------- MiniMQTT Client (ES5)
@@ -2286,6 +2323,35 @@ function setupHomeAssistant() {
       });
     }
 
+    /*
+     * Panel-lifecycle entities only exist on OLED. On an LCD/QNED set the
+     * counters simply are not there, and publishing them would give Home
+     * Assistant a permanently "unknown" sensor - or worse, a confident 0 that
+     * looks like a real reading. Retained discovery configs are cleared so
+     * they disappear from HA rather than lingering as orphans.
+     */
+    var OLED_ONLY = {
+      oled_panel_hours: 1, oled_hours_since_compensation: 1,
+      oled_hours_until_compensation: 1, oled_hours_since_refresher: 1,
+      oled_hours_until_refresher: 1, oled_refresher_status: 1,
+      oled_screen_shift: 1, oled_logo_dimming: 1,
+      pixel_refresher_schedule: 1
+    };
+    if (isOled === false) {
+      var kept = [];
+      for (var d = 0; d < entities.length; d++) {
+        if (OLED_ONLY[entities[d].id]) {
+          var dead = discPfx + '/' + entities[d].type + '/' + devId + '/' + entities[d].id + '/config';
+          mqttClient.publish(dead, '', true);   // retained empty = remove
+        } else {
+          kept.push(entities[d]);
+        }
+      }
+      console.log('mqtt: not an OLED panel, withheld ' +
+                  (entities.length - kept.length) + ' panel entities');
+      entities = kept;
+    }
+
     for (var i = 0; i < entities.length; i++) {
       var item = entities[i];
       var conf = item.payload;
@@ -2321,7 +2387,9 @@ function setupHomeAssistant() {
                 (useTls ? ' (tls)' : ' (plaintext)'));
     mqttClient.publish(statusTopic, 'online', true);
     mqttClient.publish(stateScreenTopic, 'ON', true);
-    publishDiscovery();
+    // Resolve the panel type first: publishDiscovery filters on it, and on a
+    // first connect it would otherwise still be undetermined.
+    detectOled(function () { publishDiscovery(); });
     mqttClient.subscribe(pfx + '/command/#');
     publishTelemetry();
   });

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -14,6 +14,7 @@ var http = require('http');
 var fs = require('fs');
 var url = require('url');
 var net = require('net');
+var tls = require('tls');
 var child_process = require('child_process');
 var path = require('path');
 var execFile = child_process.execFile;
@@ -42,7 +43,13 @@ var CONFIG = {
     // every install at whatever happens to be at that IP on the user's LAN.
     enabled: false,
     host: '',
-    port: 1883,
+    // null means "pick by transport": 1883 plain, 8883 with tls. A literal
+    // 1883 here would survive the config merge and silently defeat that.
+    port: null,
+    // Encrypt the broker connection. Without this the username and password
+    // cross the network in cleartext. Port defaults to 8883 when enabled.
+    tls: false,
+    tlsRejectUnauthorized: true,
     username: '',
     password: '',
     topicPrefix: 'lgtv',
@@ -58,8 +65,19 @@ var CONFIG = {
   }
 };
 
+/* Scanned before loadConfig so --config can point at an alternative file:
+   handy for a second TV, or for testing without touching the live config. */
+function argvConfigPath() {
+  var a = process.argv.slice(2);
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] === '--config' && a[i + 1]) return a[i + 1];
+  }
+  return null;
+}
+
 function loadConfig() {
-  var paths = ['/var/lib/tvweb/config.json', './config.json'];
+  var override = argvConfigPath();
+  var paths = override ? [override] : ['/var/lib/tvweb/config.json', './config.json'];
   for (var i = 0; i < paths.length; i++) {
     try {
       if (fs.existsSync(paths[i])) {
@@ -74,6 +92,22 @@ function loadConfig() {
           } else {
             CONFIG[k] = userConf[k];
           }
+        }
+        /*
+         * The file holds broker credentials in plaintext. Default webOS perms
+         * leave it world-readable (0644), and TV apps run as wam/nobody - so
+         * tighten it to owner-only. Note this is mitigation, not a fix: while
+         * the homebrew root telnet on port 23 is open, nothing on this TV is
+         * secret. Use a dedicated, ACL-restricted broker user.
+         */
+        try {
+          var mode = fs.statSync(paths[i]).mode & 0777;
+          if (mode !== 0600) {
+            fs.chmodSync(paths[i], 0600);
+            console.log('tightened permissions on ' + paths[i] + ' to 0600');
+          }
+        } catch (e) {
+          console.error('warning: could not chmod ' + paths[i] + ': ' + e.message);
         }
         console.log('loaded configuration from ' + paths[i]);
         break;
@@ -96,6 +130,7 @@ loadConfig();
   for (var i = 0; i < a.length; i++) {
     if (a[i] === '--port' && a[i + 1]) CONFIG.port = parseInt(a[++i], 10) || CONFIG.port;
     else if (a[i] === '--host' && a[i + 1]) CONFIG.host = a[++i];
+    else if (a[i] === '--config') i++;   // consumed before loadConfig
     else if (a[i] === '--no-mqtt') { CONFIG.mqtt = CONFIG.mqtt || {}; CONFIG.mqtt.enabled = false; }
     else if (a[i] === '--no-control') CONFIG.allowControl = false;
   }
@@ -1682,10 +1717,29 @@ MiniMQTT.prototype.connect = function() {
   if (this.client) return;
   clearTimeout(this.retryTimer);
 
-  var socket = net.createConnection({ host: this.opts.host, port: this.opts.port || 1883 });
+  /*
+   * Plain TCP by default, since that is what a typical home broker listens on.
+   * With mqtt.tls set, connect over TLS instead - otherwise the username and
+   * password cross the LAN in cleartext inside every CONNECT packet, and a
+   * reconnect loop resends them every few seconds.
+   */
+  var socket;
+  if (this.opts.tls) {
+    socket = tls.connect({
+      host: this.opts.host,
+      port: this.opts.port || 8883,
+      servername: this.opts.host,
+      // Self-signed broker certs are common on home networks. Turning this
+      // off keeps the traffic encrypted but stops authenticating the broker,
+      // so only do it on a network you trust.
+      rejectUnauthorized: this.opts.tlsRejectUnauthorized !== false
+    });
+  } else {
+    socket = net.createConnection({ host: this.opts.host, port: this.opts.port || 1883 });
+  }
   this.client = socket;
 
-  socket.on('connect', function() {
+  socket.on(self.opts.tls ? 'secureConnect' : 'connect', function() {
     var protoName = toBuffer([0, 4, 77, 81, 84, 84]); // 'MQTT'
     var protoLevel = toBuffer([4]); // 3.1.1
     var flags = 0x02; // CleanSession
@@ -1739,7 +1793,7 @@ MiniMQTT.prototype.connect = function() {
     self.client = null;
     clearInterval(self.pingTimer);
     if (wasConnected) {
-      console.log('mqtt: disconnected from ' + self.opts.host + ':' + (self.opts.port || 1883));
+      console.log('mqtt: disconnected from ' + self.opts.host + ':' + (self.opts.port || (self.opts.tls ? 8883 : 1883)));
       self.emit('close');
     }
     self.retryTimer = setTimeout(function() { self.connect(); }, 5000);
@@ -1873,9 +1927,12 @@ function setupHomeAssistant() {
     sw_version: (CONFIG.device && CONFIG.device.sw_version) || 'webOS (tvweb)'
   };
 
+  var useTls = !!CONFIG.mqtt.tls;
   var mqttClient = new MiniMQTT({
     host: CONFIG.mqtt.host,
-    port: CONFIG.mqtt.port || 1883,
+    port: CONFIG.mqtt.port || (useTls ? 8883 : 1883),
+    tls: useTls,
+    tlsRejectUnauthorized: CONFIG.mqtt.tlsRejectUnauthorized !== false,
     username: CONFIG.mqtt.username || null,
     password: CONFIG.mqtt.password || null,
     clientId: (CONFIG.mqtt.clientId || (devId + '_tvweb')),
@@ -2260,7 +2317,8 @@ function setupHomeAssistant() {
   }
 
   mqttClient.on('connect', function() {
-    console.log('mqtt: connected to ' + CONFIG.mqtt.host + ':' + (CONFIG.mqtt.port || 1883));
+    console.log('mqtt: connected to ' + CONFIG.mqtt.host + ':' + mqttClient.opts.port +
+                (useTls ? ' (tls)' : ' (plaintext)'));
     mqttClient.publish(statusTopic, 'online', true);
     mqttClient.publish(stateScreenTopic, 'ON', true);
     publishDiscovery();

--- a/server/tvwebctl
+++ b/server/tvwebctl
@@ -1,0 +1,46 @@
+#!/bin/sh
+# tvwebctl - start/stop/restart the tvweb server on the TV.
+#
+# Exists as a script rather than an inline ssh command on purpose: `pkill -f
+# tvweb.js` typed into an ssh command matches the remote shell running that
+# very command (its argv contains the path), so the shell kills itself before
+# starting anything. Inside a script, the shell's argv is just this file.
+#
+# Usage: tvwebctl {start|stop|restart|status}
+
+APP=/var/lib/tvweb/tvweb.js
+LOG=/var/lib/tvweb/tvweb.log
+PIDFILE=/var/run/tvweb.pid
+NODE=/usr/bin/node
+
+stop() {
+  start-stop-daemon -K -q -p "$PIDFILE" 2>/dev/null
+  # Catch instances started before this script existed.
+  for p in $(ps -eo pid,args 2>/dev/null | grep "$APP" | grep -v grep | awk '{print $1}'); do
+    [ "$p" = "$$" ] && continue
+    kill -9 "$p" 2>/dev/null
+  done
+  rm -f "$PIDFILE"
+}
+
+start() {
+  [ -x "$NODE" ] || { echo "node not found at $NODE"; exit 1; }
+  [ -f "$APP" ]  || { echo "not installed: $APP"; exit 1; }
+  chmod 600 /var/lib/tvweb/config.json 2>/dev/null
+  # -b detaches and -m writes the pidfile, so the process survives the ssh
+  # session closing. `setsid ... &` alone does not.
+  start-stop-daemon -S -b -m -p "$PIDFILE" -x /bin/sh -- -c "exec $NODE $APP >$LOG 2>&1"
+}
+
+case "$1" in
+  start)   start ;;
+  stop)    stop ;;
+  restart) stop; sleep 1; start ;;
+  status)
+    if [ -f "$PIDFILE" ] && kill -0 "$(cat $PIDFILE)" 2>/dev/null; then
+      echo "running (pid $(cat $PIDFILE))"
+    else
+      echo "not running"
+    fi ;;
+  *) echo "usage: $0 {start|stop|restart|status}"; exit 2 ;;
+esac


### PR DESCRIPTION


- Harden the MQTT bridge
- Prefer SSH over telnet
- Gate OLED-only features

## Testing

- OLED path unchanged on the B8: 33 entities, `panel: OLED (paneltype_oled present)`.
- Simulated LCD payload hides the panel block while keeping flash, temperature and controls.
- Full SSH deploy verified, including boot-hook install and surviving disconnect.