### PR TITLE
Make the web dashboard toggleable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,21 @@ no root access, and recovery means re-rooting the TV.
 cp config.example.json server/config.json
 ```
 
-Set your broker under `mqtt` and turn it on. Leave `mqtt.enabled` false if you
-only want the dashboard. Leaving `device.name` and `device.model` empty makes
-the TV report its own model and firmware at runtime.
+Set your broker under `mqtt` and turn it on. Leaving `device.name` and
+`device.model` empty makes the TV report its own model and firmware at runtime.
+
+Both halves are independent, so run whichever you want:
+
+| | `web.enabled` | `mqtt.enabled` |
+| :--- | :--- | :--- |
+| Dashboard and Home Assistant *(default)* | `true` | `true` |
+| Dashboard only | `true` | `false` |
+| Home Assistant only | `false` | `true` |
+
+If you drive everything from Home Assistant, set `"web": { "enabled": false }`.
+The dashboard is an unauthenticated control endpoint unless you set `token`, so
+an MQTT-only install is better off without one. With both disabled the server
+exits rather than idling.
 
 `allowPower` ships disabled, because there is no authentication unless you set
 `token` &mdash; a fresh install should not expose "turn the TV off" to the whole
@@ -170,10 +182,11 @@ Nothing on the TV's read-only rootfs is ever modified.
 
 ## Security
 
-The server has **no authentication by default** and binds to `0.0.0.0`, so
+The dashboard has **no authentication by default** and binds to `0.0.0.0`, so
 anyone who can reach the port can use every enabled control. On a home LAN that
 is usually the point &mdash; but set `"token": "something-long"` in
-`config.json` if you want it gated, and never port-forward it.
+`config.json` if you want it gated, and never port-forward it. If you only use
+Home Assistant, `"web": { "enabled": false }` removes the endpoint entirely.
 
 Setting a token affects the dashboard only. **Home Assistant is unaffected**,
 since MQTT is a separate channel.

--- a/config.example.json
+++ b/config.example.json
@@ -1,4 +1,7 @@
 {
+  "web": {
+    "enabled": true
+  },
   "port": 8080,
   "host": "0.0.0.0",
   "allowControl": true,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -11,6 +11,9 @@ it before exposing it more widely.
   Assistant integration are unaffected**, since they use a separate channel.
 - **`allowPower` ships disabled**, so a fresh install cannot be told to turn the
   TV off by anything that finds the port. Enable it deliberately.
+- **Turn the dashboard off if you do not use it.** `"web": { "enabled": false }`
+  removes the HTTP endpoint altogether, which is stronger than gating it with a
+  token. An MQTT-only install has no reason to expose one.
 - **Never port-forward this.** It is designed for a trusted LAN.
 - Bind to `127.0.0.1` instead of `0.0.0.0` if you only want the TV itself to
   reach it.

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -126,7 +126,26 @@ else
 fi
 
 echo
+# With the dashboard switched off there is no HTTP endpoint to poll, so report
+# the log instead of a false failure.
+WEB_OFF=""
+if [ -f "$DIR/config.json" ] && command -v python3 >/dev/null 2>&1; then
+  WEB_OFF=$(python3 -c 'import json,sys
+try:
+    c = json.load(open(sys.argv[1]))
+    print("1" if c.get("web", {}).get("enabled") is False else "")
+except Exception:
+    print("")' "$DIR/config.json" 2>/dev/null || true)
+fi
+
 echo "verifying ..."
-curl -s --max-time 8 "http://$TV:8080/api/caps" || echo "(no response yet - give it a moment)"
-echo
-echo "open  http://$TV:8080/"
+if [ -n "$WEB_OFF" ]; then
+  echo "dashboard disabled in config (web.enabled=false) - mqtt bridge only."
+  if use_ssh; then
+    ssh "${SSH_OPTS[@]}" "root@$TV" 'tail -4 /var/lib/tvweb/tvweb.log' 2>/dev/null
+  fi
+else
+  curl -s --max-time 8 "http://$TV:8080/api/caps" || echo "(no response yet - give it a moment)"
+  echo
+  echo "open  http://$TV:8080/"
+fi

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -21,7 +21,12 @@ var execFile = child_process.execFile;
 
 // ---------------------------------------------------------------- config
 var CONFIG = {
-  port: 8080,
+  // The dashboard. Turn this off if you drive everything from Home Assistant:
+  // it is an unauthenticated control endpoint unless `token` is set, and an
+  // MQTT-only install has no reason to expose one.  { "web": { "enabled": false } }
+  web: { enabled: true },
+
+  port: 8080,           // dashboard port
   host: '0.0.0.0',      // '127.0.0.1' to keep it TV-local only
 
   // Anyone who can reach this port can use the controls below.
@@ -1573,6 +1578,8 @@ var PAGE = [
  * PAGE above stays as a fallback: if the asset is missing the server still
  * serves a working dashboard instead of a blank screen.
  */
+var WEB_ENABLED = !(CONFIG.web && CONFIG.web.enabled === false);
+
 var ASSET_DIRS = [
   path.join(__dirname, 'assets'),
   '/var/lib/tvweb/assets'
@@ -1594,6 +1601,7 @@ function assetPath(rel) {
 
 var UI_HTML = null;
 (function loadUI() {
+  if (!WEB_ENABLED) return;   // nothing will serve it
   var f = assetPath('ui.html');
   if (!f) { console.log('assets: ui.html not found, using embedded page'); return; }
   try {
@@ -1632,7 +1640,7 @@ function authed(q) {
   return !CONFIG.token || q.k === CONFIG.token;
 }
 
-http.createServer(function (req, res) {
+var server = http.createServer(function (req, res) {
   var u = url.parse(req.url, true);
   var pathname = u.pathname;
 
@@ -1704,12 +1712,33 @@ http.createServer(function (req, res) {
   }
 
   send(res, 404, JSON.stringify({ ok: false, error: 'not found' }));
-}).listen(CONFIG.port, CONFIG.host, function () {
-  console.log('tvweb listening on ' + CONFIG.host + ':' + CONFIG.port +
-              '  control=' + CONFIG.allowControl + '  power=' + CONFIG.allowPower +
-              '  auth=' + (CONFIG.token ? 'token' : 'none'));
-  detectOled(function () {});   // resolve and log panel type up front
 });
+
+var webEnabled = WEB_ENABLED;
+var mqttEnabled = !!(CONFIG.mqtt && CONFIG.mqtt.enabled && CONFIG.mqtt.host);
+
+/*
+ * Refuse to sit there looking healthy while doing nothing. With both the
+ * dashboard and the MQTT bridge switched off there is no reason for the
+ * process to exist, and a silent no-op is harder to diagnose than an exit.
+ */
+if (!webEnabled && !mqttEnabled) {
+  console.error('nothing to do: web.enabled is false and mqtt is not configured.');
+  console.error('enable one of them in config.json.');
+  process.exit(1);
+}
+
+if (webEnabled) {
+  server.listen(CONFIG.port, CONFIG.host, function () {
+    console.log('tvweb listening on ' + CONFIG.host + ':' + CONFIG.port +
+                '  control=' + CONFIG.allowControl + '  power=' + CONFIG.allowPower +
+                '  auth=' + (CONFIG.token ? 'token' : 'none'));
+    detectOled(function () {});   // resolve and log panel type up front
+  });
+} else {
+  console.log('web dashboard disabled (web.enabled=false) - mqtt bridge only');
+  detectOled(function () {});
+}
 
 // ---------------------------------------------------------------- MiniMQTT Client (ES5)
 function encodeVarLength(len) {


### PR DESCRIPTION
## Why

The MQTT bridge could be switched off but the dashboard could not. An install driving everything from Home Assistant therefore had to keep an **unauthenticated control endpoint** open on the LAN — volume, inputs, screen, power — for no benefit.

Setting `token` gates it. `"web": { "enabled": false }` removes it entirely, which is the better answer when nobody is using it.

Defaults to `true`, so existing installs are unchanged.

## Config

Both halves are now independent:

| | `web.enabled` | `mqtt.enabled` |
| :--- | :--- | :--- |
| Dashboard and Home Assistant *(default)* | `true` | `true` |
| Dashboard only | `true` | `false` |
| Home Assistant only | `false` | `true` |

## Also

- **Both disabled now exits non-zero** with a reason. Previously the process would sit there looking healthy while doing nothing, which is harder to diagnose than a failure.
- **The UI asset is no longer loaded when nothing will serve it** — it was logging `serving ui.html` in a mode where it does no such thing.
- **`deploy.sh` no longer reports a false failure** in MQTT-only mode: with no HTTP endpoint to poll it reads back the log instead of curling `/api/caps`.

## Testing

All three states run on the TV:

- Dashboard + MQTT: unchanged, 33 entities, `/api/caps` responding.
- MQTT only: no listening port, logs `web dashboard disabled (web.enabled=false) - mqtt bridge only`.
- Both off: exits `1` with `nothing to do: web.enabled is false and mqtt is not configured.`