### PR TITLE
Audit MQTT entity state sources; add a check for template drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# Writing conventions
+
+Applies to commit messages, PR descriptions, release notes, README and docs.
+
+## Keep it short
+
+State what changed and why. Stop. A PR description is usually a paragraph or
+two, not a report.
+
+Length should track the size of the change, not the effort behind it. A
+one-line fix gets one line.
+
+## Don't narrate the work
+
+No process commentary: what was tried, what was ruled out, what turned out to
+be a false alarm, how something was verified. If a check found nothing, that
+is not a finding worth writing down.
+
+Record decisions and their reasons, not the route taken to reach them.
+
+## Third person, always
+
+These are project artefacts, not messages to a reader. Never "you", "your TV",
+"as you asked". Write "the TV", "the panel switch".
+
+## No filler structure
+
+Don't add headings, tables or bullet lists to a short change. Tables are for
+genuine matrices - a compatibility list, a unit reference - not for restating
+three sentences.
+
+Don't list things that did not change.
+
+## Comments in code
+
+Explain why, where a reader would otherwise wonder or get it wrong: a platform
+quirk, a non-obvious ordering constraint, a value that looks wrong but isn't.
+Skip comments that restate the code.
+
+Keep the measured facts that justify a decision (an observed value, a version,
+a threshold). Drop the story around them.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -231,33 +231,19 @@ that only targets advertising and telemetry.
 
 ## Entity state must come from the TV, not from the command
 
-Home Assistant entities here derive their state from the telemetry payload via
-a `value_template`, so they re-assert the truth on every tick no matter where a
-change came from - the dashboard, the remote, the TV's own menus, or Home
-Assistant itself.
+Entities derive state from the telemetry payload via a `value_template`, so
+they re-assert the truth on every tick whatever changed it - dashboard, remote,
+the TV's own menus, or Home Assistant.
 
-The display panel switch originally did not. It published its state only when
-the command arrived over MQTT, and published a retained `ON` on every connect.
-Blanking the panel from the dashboard therefore left Home Assistant showing it
-on indefinitely, and a reconnect would silently flip it back on and look
-authoritative. It is now reconciled against `powerState` on each telemetry
-publish.
+The display panel switch originally published only when a command arrived over
+MQTT, plus a retained `ON` on every connect. Blanking the panel from the
+dashboard left Home Assistant showing it on indefinitely. It is now reconciled
+against `powerState` each telemetry publish.
 
-Two rules follow, for anything added later:
+So: prefer `state_topic: telemetryTopic` with a template. An entity on its own
+topic must be republished from real state every tick, or it is a guess that
+holds until someone notices.
 
-1. Prefer `state_topic: telemetryTopic` with a `value_template`. Such an entity
-   is self-correcting by construction.
-2. If an entity genuinely needs its own topic, something must republish it from
-   real state on every telemetry tick. A command-time publish alone is a guess
-   that survives until someone notices.
-
-`scripts/check-entities.py` walks every discovery entity, extracts the
-`value_json` paths its template uses, and resolves each against a live
-`/api/stats` response. A renamed field otherwise just leaves an entity stuck at
-`unknown`, which is easy to miss for a long time.
-
-```
-$ ./scripts/check-entities.py 192.168.1.134
-54 paths checked across 34 entities
-all entity templates resolve against the live payload
-```
+`scripts/check-entities.py` resolves every entity's `value_json` paths against a
+live `/api/stats`. A renamed field otherwise leaves an entity at `unknown` with
+no error anywhere.

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -226,3 +226,38 @@ events unless told, so it is stated at the toggle in the UI as well as here.
 
 Removing those two entries from `ADBLOCK_DOMAINS` gives a conservative list
 that only targets advertising and telemetry.
+
+---
+
+## Entity state must come from the TV, not from the command
+
+Home Assistant entities here derive their state from the telemetry payload via
+a `value_template`, so they re-assert the truth on every tick no matter where a
+change came from - the dashboard, the remote, the TV's own menus, or Home
+Assistant itself.
+
+The display panel switch originally did not. It published its state only when
+the command arrived over MQTT, and published a retained `ON` on every connect.
+Blanking the panel from the dashboard therefore left Home Assistant showing it
+on indefinitely, and a reconnect would silently flip it back on and look
+authoritative. It is now reconciled against `powerState` on each telemetry
+publish.
+
+Two rules follow, for anything added later:
+
+1. Prefer `state_topic: telemetryTopic` with a `value_template`. Such an entity
+   is self-correcting by construction.
+2. If an entity genuinely needs its own topic, something must republish it from
+   real state on every telemetry tick. A command-time publish alone is a guess
+   that survives until someone notices.
+
+`scripts/check-entities.py` walks every discovery entity, extracts the
+`value_json` paths its template uses, and resolves each against a live
+`/api/stats` response. A renamed field otherwise just leaves an entity stuck at
+`unknown`, which is easy to miss for a long time.
+
+```
+$ ./scripts/check-entities.py 192.168.1.134
+54 paths checked across 34 entities
+all entity templates resolve against the live payload
+```

--- a/scripts/check-entities.py
+++ b/scripts/check-entities.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Check that every Home Assistant entity derives its state from something the TV
+actually reports.
+
+The display panel switch once published its state only when the command
+arrived over MQTT, so blanking the panel from the dashboard or the remote left
+Home Assistant asserting the opposite forever. Templates can also drift from
+the telemetry payload silently - a renamed field just yields an entity stuck
+at "unknown", which nobody notices for weeks.
+
+This walks every discovery entity in tvweb.js, extracts the value_json paths
+its template references, and resolves each against a live /api/stats response.
+
+    ./scripts/check-entities.py [tv-ip]
+
+Exits non-zero if any path fails to resolve.
+"""
+import json, re, sys, urllib.request, pathlib
+
+tv = sys.argv[1] if len(sys.argv) > 1 else '192.168.1.134'
+src = (pathlib.Path(__file__).parent.parent / 'server' / 'tvweb.js').read_text(encoding='utf-8')
+
+try:
+    with urllib.request.urlopen(f'http://{tv}:8080/api/stats', timeout=10) as r:
+        stats = json.load(r)
+except Exception as e:
+    sys.exit(f'could not reach {tv}: {e}')
+
+
+def resolve(path):
+    cur = stats
+    for part in path.split('.'):
+        if isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            return False
+    return True
+
+
+blocks = re.findall(
+    r"type: '(switch|number|select|sensor)', id: '([a-z0-9_]+)',\s*payload: \{(.*?)\n        \}",
+    src, re.S)
+
+failures, checked = [], 0
+print(f'{"entity":30} {"state source":14} paths')
+print('-' * 74)
+for typ, eid, body in blocks:
+    source = ('telemetry' if 'telemetryTopic' in body
+              else 'own topic' if 'Topic' in body else 'none')
+    tmpl = re.search(r"value_template:\s*'(.*?)'", body, re.S)
+    paths = sorted(set(re.findall(r'value_json\.([A-Za-z0-9_.]+)', tmpl.group(1)))) if tmpl else []
+    bad = [p for p in paths if not resolve(p)]
+    checked += len(paths)
+    status = ', '.join(paths) if paths else '(no template)'
+    print(f'{eid:30} {source:14} {"FAIL " if bad else ""}{status}')
+    for p in bad:
+        print(f'{"":46} MISSING: {p}')
+        failures.append(f'{eid}: {p}')
+
+    # Entities on their own topic cannot self-correct from the telemetry
+    # payload, so flag them for a human to confirm something republishes them
+    # from real state. Only display_panel is in this position today.
+    if source == 'own topic':
+        print(f'{"":46} note: own topic - confirm it is republished from real state')
+
+print()
+print(f'{checked} paths checked across {len(blocks)} entities')
+if failures:
+    print(f'{len(failures)} unresolved:')
+    for f in failures:
+        print('  ' + f)
+    sys.exit(1)
+print('all entity templates resolve against the live payload')


### PR DESCRIPTION
Follow-up to `4a0d32c`.

Audited the other stateful entities for the same problem. All of them derive state from the telemetry payload via a `value_template`, so they self-correct on every tick. `display_panel` was the only entity on its own topic, and the only one that could go stale.

Adds `scripts/check-entities.py`, which resolves every entity's `value_json` paths against a live `/api/stats`. This failure is silent — a renamed telemetry field leaves an entity sitting at `unknown` with no error anywhere.

`docs/IMPLEMENTATION.md` records the rule: prefer telemetry-backed templates; an entity on its own topic must be republished from real state each tick.
