### PR TITLE
Attribute HDMI signal to the right input; add the network name

### DIFF
--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -282,15 +282,11 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="grp">Advanced</div>
       <details class="disc" id="disc-hdmi" style="border-top:0;margin-top:0">
       <summary>HDMI <span class="cur" id="hdmi-cur"></span></summary>
-      <div class="sub" style="margin:10px 0 6px">Link state straight off the HDMI
-        receiver &mdash; what each port is actually negotiating.</div>
       <div id="hdmi-list"></div>
     </details>
 
       <details class="disc" id="disc-proc">
       <summary>Processes <span class="cur" id="proc-cur"></span></summary>
-      <div class="sub" style="margin:10px 0 6px">What is resident in memory. Read-only &mdash;
-        close an app from Source or the app itself rather than killing a process.</div>
       <div id="proc-list"></div>
     </details>
     </div>

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -252,6 +252,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <section class="readouts" id="readouts"></section>
       <div class="cols" style="margin-top:20px">
         <div><div class="lbl">GPU clock</div><div class="v num" id="gpuclk">&mdash;</div></div>
+        <div id="ssid-cell" hidden><div class="lbl">Network</div><div class="v" id="ssid">&mdash;</div><div class="sub">Connected Wi-Fi</div></div>
       </div>
     </div>
 
@@ -705,6 +706,8 @@ async function tick() {
     // GPU clock, panel dimming, app storage and the ambient sensor. Each is
     // hidden when the set does not report it rather than showing a dash.
     q('gpuclk').textContent = d.gpuMhz ? d.gpuMhz + ' MHz' : '—';
+    q('ssid-cell').hidden = !d.ssid;      // wired sets report none
+    if (d.ssid) q('ssid').textContent = d.ssid;
     const dim = d.dimming;
     q('dimming-cell').hidden = !dim;
     if (dim) q('dimming').textContent = dim.charAt(0).toUpperCase() + dim.slice(1);
@@ -908,18 +911,19 @@ async function loadHdmi() {
   try {
     const r = await fetch(api('/api/hdmi'), { cache: 'no-store' });
     const d = await r.json();
-    const live = d.ports.filter(p => p.connected);
-    q('hdmi-cur').textContent = live.length
-      ? live.map(p => p.label.replace('HDMI ', 'HDMI')).join(', ') + ' active'
-      : 'nothing connected';
-    q('hdmi-list').innerHTML = d.ports.map(p => {
-      const detail = p.connected
-        ? [p.resolution, p.refreshHz ? p.refreshHz + ' Hz' : null, p.colorDepth,
-           p.pixelClockMhz ? p.pixelClockMhz + ' MHz pixel clock' : null,
-           p.interlaced ? 'interlaced' : null].filter(Boolean).join(' · ')
-        : 'No source detected';
-      return `<div class="proc"><div class="p-name">${p.label}<div class="sub">${detail}</div></div>` +
-             `<div class="p-mb">${p.connected ? 'Linked' : '—'}</div></div>`;
+    const act = d.inputs.find(i => i.active);
+    q('hdmi-cur').textContent = act ? act.label : 'no active input';
+    q('hdmi-list').innerHTML = d.inputs.map(i => {
+      const s = i.signal;
+      const detail = s
+        ? [s.resolution, s.refreshHz ? s.refreshHz + ' Hz' : null, s.colorDepth,
+           s.pixelClockMhz ? s.pixelClockMhz + ' MHz pixel clock' : null,
+           s.interlaced ? 'interlaced' : null].filter(Boolean).join(' · ')
+        : (i.deviceSeen ? 'Device seen, no signal' : 'Nothing connected');
+      const state = i.active ? 'Active' : (i.deviceSeen ? 'Idle' : '—');
+      return `<div class="proc"><div class="p-name">${esc(i.label)}` +
+             `<div class="sub">HDMI ${i.port} · ${detail}</div></div>` +
+             `<div class="p-mb">${state}</div></div>`;
     }).join('');
   } catch (e) {
     q('hdmi-list').innerHTML = `<div class="sub">Could not read HDMI state — ${e.message}</div>`;

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -753,6 +753,10 @@ function collectStats(cb) {
       hasLogo: hasLogoLight === true
     };
     out.gpuMhz = gpuClockMhz();
+  luna('com.palm.connectionmanager/getStatus', {}, function (cm) {
+    // Network name, so the Wi-Fi figures say which network they refer to.
+    var w = cm && cm.wifi;
+    out.ssid = (w && w.ssid) ? w.ssid : null;
   luna('com.webos.service.tv.display/getDimmingStatus', {}, function (dim) {
     // ABL / logo dimming activity. OLED only in practice.
     out.dimming = (dim && dim.status) || null;
@@ -838,6 +842,7 @@ function collectStats(cb) {
     );
   });
   });   // close appStorage
+  });   // close connectionmanager
   });   // close light sensor
   });   // close dimming
   });   // close option settings
@@ -909,6 +914,14 @@ function appStorage(cb) {
  * HDMI PHY state, straight off the receiver. Loaded on demand rather than in
  * telemetry: four ports of timing detail is a lot to publish every ten seconds
  * and it only matters when someone is looking at it.
+ *
+ * The PHY nodes are port0..port3 while the TV numbers its inputs HDMI 1..4,
+ * and the obvious port+1 mapping is wrong: on a set whose only live input is
+ * HDMI 2 (eim reports activate/chosen true, a CEC device present, everything
+ * else empty) the port carrying signal is port2, not port1. There is no
+ * hotplug or EDID field to pin the rest of the mapping down, so this does not
+ * guess. Ports are reported as-is, and the input the TV says is active is
+ * matched to the one port carrying signal when exactly one of each exists.
  */
 function hdmiPorts() {
   var ports = [];
@@ -919,28 +932,59 @@ function hdmiPorts() {
     var hact = parseInt(f(/horizontal-active:\s*(\d+)/) || '0', 10);
     var vact = parseInt(f(/vertical-active:\s*(\d+)/) || '0', 10);
     /*
-     * Use pixel-clock-V, not the field labelled refresh-rate. The latter
-     * reports 793 "(0.01Hz)" on a 4K60 source, i.e. 7.9Hz, which is wrong.
-     * pixel-clock-V reads 60 and checks out against the timings:
-     * 4400 x 2250 x 60 = 594 MHz against a reported 595.1 MHz pixel clock.
+     * Refresh rate comes from pixel-clock-V, not the field labelled
+     * refresh-rate: that reports 793 "(0.01Hz)" on a 4K60 source. pixel-clock-V
+     * reads 60 and checks out against the timings.
      */
     var rate = parseInt(f(/pixel-clock-V:\s*(\d+)/) || '0', 10);
     var pclk = parseInt(f(/pixel-clock:\s*(\d+)/) || '0', 10);
     ports.push({
       port: i,
-      label: 'HDMI ' + (i + 1),
       connected: /connected:\s*on/i.test(raw),
       resolution: (hact && vact) ? (hact + 'x' + vact) : null,
-      // refresh-rate is reported in hundredths of a Hz
       refreshHz: rate || null,
       pixelClockMhz: pclk ? Math.round(pclk / 1000 * 10) / 10 : null,
       colorDepth: f(/deep-color-mode:\s*(\S+ \S+)/),
-      interlaced: /interlaced:\s*yes/i.test(raw),
-      audioChannelCount: f(/AIF-CC2-0:\s*(0x[0-9a-f]+)/i),
-      audioSampleFreq: f(/AIF-SF2-0:\s*(0x[0-9a-f]+)/i)
+      interlaced: /interlaced:\s*yes/i.test(raw)
     });
   }
   return ports;
+}
+
+/*
+ * Inputs as the TV describes them, with the live PHY figures attached to the
+ * active one. The labels are the TV's own, so a renamed input reads "Apple TV"
+ * rather than a port number this code guessed at.
+ */
+function hdmiInputs(cb) {
+  luna('com.webos.service.eim/getAllInputStatus', {}, function (res) {
+    var devs = (res && res.devices) || [];
+    var ports = hdmiPorts();
+    var signalling = [];
+    for (var p = 0; p < ports.length; p++) if (ports[p].connected) signalling.push(ports[p]);
+
+    var inputs = [];
+    var activeIdx = -1;
+    for (var d = 0; d < devs.length; d++) {
+      if (!devs[d].id || String(devs[d].id).indexOf('HDMI') !== 0) continue;
+      if (devs[d].activate) activeIdx = inputs.length;
+      inputs.push({
+        id: devs[d].id,
+        port: devs[d].port,
+        label: devs[d].label || devs[d].id,
+        appId: devs[d].appId,
+        active: !!devs[d].activate,
+        // lastUniqueId 255 means nothing has ever identified itself over CEC
+        deviceSeen: devs[d].lastUniqueId !== undefined && devs[d].lastUniqueId !== 255,
+        signal: null
+      });
+    }
+    // Only claim a pairing when it is unambiguous.
+    if (activeIdx !== -1 && signalling.length === 1) {
+      inputs[activeIdx].signal = signalling[0];
+    }
+    cb({ ok: true, inputs: inputs, ports: ports, pairedUnambiguously: (activeIdx !== -1 && signalling.length === 1) });
+  });
 }
 
 // ---------------------------------------------------------------- privacy
@@ -2319,7 +2363,7 @@ var server = http.createServer(function (req, res) {
   }
 
   if (pathname === '/api/hdmi') {
-    return send(res, 200, JSON.stringify({ ok: true, ports: hdmiPorts() }));
+    return hdmiInputs(function (r) { send(res, 200, JSON.stringify(r)); });
   }
 
   if (pathname === '/api/processes') {


### PR DESCRIPTION
The HDMI panel reported the live signal as HDMI 3. It is HDMI 2.

The PHY nodes are `port0..port3` while the TV numbers its inputs HDMI 1..4, and `port + 1` was wrong. On a set whose only live input is HDMI 2 — eim reports it `activate`/`chosen` with a CEC device present, every other input empty — the port carrying signal is `port2`.

There is no hotplug or EDID field to pin the remaining mapping down, so the code no longer guesses one. Inputs come from the TV with its own labels, and the active input is paired to the single port carrying signal when exactly one of each exists:

```
HDMI 1     HDMI 1 · Nothing connected                                    —
Apple TV   HDMI 2 · 3840x2160 · 60 Hz · 24 bpp · 595.1 MHz pixel clock   Active
HDMI 3     HDMI 3 · Nothing connected                                    —
HDMI 4     HDMI 4 · Nothing connected                                    —
```

Also adds the connected network name beside the GPU clock, which stops that figure sitting alone in its row. Hidden on wired sets.

On the label sizes: `PROCESSOR` and `GPU CLOCK` are identical — both 12px, same weight, spacing and colour. The difference was context, one sitting beside a bar and the other above a 24px value. The second item in the row settles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)