### PR TITLE
Fix three snags reported on older, non-OLED hardware

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ cd server
 ```
 
 `--persist` installs a boot hook so it survives reboots. The script copies over
-SSH where available, falling back to telnet; `--telnet` forces the old path.
+SSH where available, falling back to telnet; `--telnet` forces the old path. The
+telnet path has to find this machine's LAN address to serve the files from; if
+it cannot, pass it as `MYIP=192.168.x.y ./deploy.sh <tv-ip>`.
 
 Then open **`http://<tv-ip>:8080/`**.
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ cp config.example.json server/config.json
 
 Set your broker under `mqtt` and turn it on. Leaving `device.name` and
 `device.model` empty makes the TV report its own model and firmware at runtime.
+Panel hours, Pixel Refresher and Screen Shift appear on OLED sets only; add
+`"panel": "lcd"` or `"panel": "oled"` if a set is read the wrong way.
 
 Both halves are independent, so run whichever you want:
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ versions and panel types.
 | OLED65B8SLC | 4.4.3 | 05.50.70 | OLED | Fully working |
 | OLED65C9AUA | 4.9.x (4.5+) | 05.50.00 | OLED | Fully working |
 | OLED55C1PUB | 6.x (6.3+) | 03.53.45 | OLED | Working (SSH install, MQTT bridge) |
+| 55UH6030-UC | 3.4.3 | &mdash; | LCD | Working (LCD, so no OLED panel metrics) |
 
 **If you run it on anything else, please open an issue whether it's working or not**
 Include your model, webOS version and

--- a/server/deploy.sh
+++ b/server/deploy.sh
@@ -82,10 +82,33 @@ deploy_ssh() {
 }
 
 # ---------------------------------------------------------------- telnet path
+
+# The telnet path has no file transfer, so the TV pulls the files back over HTTP
+# and we need the LAN address it can reach us on. Every way of asking is
+# platform-specific and one of them lies: under Git Bash, `ipconfig getifaddr`
+# runs Windows' ipconfig.exe, which ignores the arguments and prints its help
+# text to stdout - so candidates are checked for the shape of an address rather
+# than merely being non-empty. Set MYIP to skip all of this.
+local_ip() {
+  tmp=$(mktemp)
+  { for i in en0 en1 en2 en3; do ipconfig getifaddr "$i"; done      # macOS
+    hostname -I | tr ' ' '\n'                                       # Linux
+    ip -4 -o addr show scope global | awk '{split($4,a,"/"); print a[1]}'
+    ipconfig | sed -n 's/.*IPv4 Address[^:]*: *\([0-9.]*\).*/\1/p'  # Windows
+  } 2>/dev/null | grep -Ex '([0-9]{1,3}\.){3}[0-9]{1,3}' | grep -v '^127\.' > "$tmp"
+
+  # Prefer an address on the TV's own subnet: Windows machines routinely carry
+  # WSL, Hyper-V and VPN adapters the TV cannot route back to.
+  awk -v p="${TV%.*}." 'index($0, p) == 1 { print; hit = 1; exit }
+                        END { if (!hit) exit 1 }' "$tmp" || head -1 "$tmp"
+  rm -f "$tmp"
+}
+
 deploy_telnet() {
-  MYIP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null \
-         || hostname -I 2>/dev/null | awk '{print $1}')
-  [ -z "$MYIP" ] && { echo "could not determine this machine's LAN IP" >&2; exit 1; }
+  MYIP="${MYIP:-$(local_ip)}"
+  [ -z "$MYIP" ] && {
+    echo "could not work out this machine's LAN IP - rerun as MYIP=192.168.x.y $0 $TV" >&2
+    exit 1; }
   echo "deploying to $TV over telnet (no ssh); serving from $MYIP:$PORT ..."
   start_http
   trap stop_http EXIT

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -508,35 +508,41 @@ var lastOledCheck = 0;
  * Pixel Refresher. Detect once and omit the whole block rather than reporting
  * a confident 0 hours, which reads as a real measurement.
  *
- * Panel type detection.
- * Three independent signals, any is sufficient:
- *   - /var/luna/preferences/paneltype_oled, written by webOS 4/5 platform
- *   - model name containing "OLED" (from systemproperty or config.json)
- *   - a panelUsageTime that actually comes back from systemproperty
+ * The model name decides it: every LG OLED is named "OLED...". panelUsageTime
+ * is not proof - some LCD firmware answers it anyway (seen on a 2016
+ * 55UH6030), which is what used to turn those sets into false OLEDs - so it
+ * only gets a say when the model name is unreadable. A "panel" in config.json
+ * overrides the lot.
  */
 var isOled = null;   // null = not yet determined
 
 function detectOled(cb) {
   if (isOled !== null) return cb(isOled);
+
+  var forced = CONFIG.panel || (CONFIG.device && CONFIG.device.panel);
+  if (forced) {
+    isOled = /oled/i.test(forced);
+    console.log('panel: ' + (isOled ? 'OLED' : 'not OLED') + ' (from config)');
+    return cb(isOled);
+  }
   if (fs.existsSync('/var/luna/preferences/paneltype_oled')) {
     isOled = true;
     console.log('panel: OLED (paneltype_oled present)');
-    return cb(true);
-  }
-  if (CONFIG.device && CONFIG.device.model && /oled/i.test(CONFIG.device.model)) {
-    isOled = true;
-    console.log('panel: OLED (model ' + CONFIG.device.model + ')');
     return cb(true);
   }
   luna('com.webos.service.tv.systemproperty/getSystemProperties',
     { keys: ['panelUsageTime', 'modelName'] },
     function (res) {
       var model = (res && res.modelName) || (CONFIG.device && CONFIG.device.model) || '';
-      var hasUsage = !!(res && res.panelUsageTime);
-      var modelOled = /oled/i.test(model);
-      isOled = hasUsage || modelOled;
-      console.log('panel: ' + (isOled ? ('OLED (' + (hasUsage ? 'panelUsageTime reported' : 'model ' + model) + ')')
-                                      : 'not OLED - panel features disabled'));
+      if (model) {
+        isOled = /oled/i.test(model);
+        console.log('panel: ' + (isOled ? 'OLED' : 'not OLED - panel features disabled') +
+                    ' (model ' + model + ')');
+      } else {
+        isOled = !!(res && res.panelUsageTime);
+        console.log('panel: no model name; falling back to panelUsageTime -> ' +
+                    (isOled ? 'OLED' : 'not OLED - panel features disabled'));
+      }
       cb(isOled);
     });
 }

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -293,12 +293,18 @@ function refreshInputNames(cb) {
   });
 }
 
+var TOAST_SOURCE = 'com.webos.app.home';
+
 /* luna-send wrapper via execFile directly, avoiding /bin/sh and shell child leaks.
  * -w 2000 tells luna-send itself to time out after 2 seconds.
  * timeout: 3500 ensures Node kills the child process if it ever stalls.
+ * appId, where given, becomes -a: a few services check the caller's registered
+ * bus identity rather than anything in the payload, and reject everyone else
+ * with "Unknown Source".
  */
-function luna(uri, payload, cb) {
-  var args = ['-n', '1', '-w', '2000', '-f', 'luna://' + uri, JSON.stringify(payload || {})];
+function luna(uri, payload, cb, appId) {
+  var args = appId ? ['-a', appId] : [];
+  args = args.concat(['-n', '1', '-w', '2000', '-f', 'luna://' + uri, JSON.stringify(payload || {})]);
   execFile('/usr/bin/luna-send', args, { timeout: 3500 }, function (err, stdout) {
     var parsed = null;
     if (!err && stdout) {
@@ -1331,9 +1337,12 @@ function doControl(action, value, cb) {
                   function (r) { cb({ ok: !!(r && r.returnValue) }); });
 
     case 'toast':
+      /* Both the payload's sourceId and luna-send's -a have to name an app the
+         bus already knows; "tvweb" is rejected as an Unknown Source. */
       return luna('com.webos.notification/createToast',
-                  { sourceId: 'tvweb', message: String(value || 'hello').slice(0, 120) },
-                  function (r) { cb({ ok: !!(r && r.returnValue) }); });
+                  { sourceId: TOAST_SOURCE, message: String(value || 'hello').slice(0, 120) },
+                  function (r) { cb({ ok: !!(r && r.returnValue), error: r && r.errorText }); },
+                  TOAST_SOURCE);
 
     case 'powerOff':
       if (!CONFIG.allowPower) return cb({ ok: false, error: 'power actions disabled (set allowPower)' });


### PR DESCRIPTION
Three issues reported on a 2016 55UH6030-UC (webOS 3.4.3, LCD).

**Panel type.** `detectOled()` treated any truthy `panelUsageTime` as proof of
an OLED panel. That firmware answers the key anyway, so an LCD set reported
Panel Hours, Pixel Refresher and Screen Shift as real measurements. The model
name decides it now — every LG OLED is named `OLED...` — and `panelUsageTime`
is consulted only when no model name comes back. `"panel": "lcd"` or
`"panel": "oled"` in config.json overrides both.

**deploy.sh on Windows.** The telnet path found this machine's LAN address with
macOS's `ipconfig getifaddr` and a `hostname -I` fallback. Under Git Bash the
former resolves to Windows' ipconfig.exe, which ignores the arguments and
prints its help text; that text became the address the TV was told to fetch
from, and the deploy failed with nothing on screen to explain it. Candidates
now come from macOS, Linux and Windows, are checked for the shape of an
address, and prefer one on the TV's subnet so WSL and VPN adapters lose. `MYIP`
overrides it. The SSH path was never affected.

**Toasts.** `createToast` rejects callers the bus does not know, whatever
`sourceId` the payload carries, so `"tvweb"` failed with Unknown Source.
`luna()` takes an optional appId to pass as `-a`; only the toast call uses it.

Verified: the panel-type logic against seven cases including the reported one,
and the address detection under a simulated Git Bash where the old code
reproduces the reported failure. The toast change is not yet confirmed on
hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)