### PR TITLE
Report platforms with no thermal sensor instead of rendering 0 °C

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ versions and panel types.
 | OLED65B8SLC | 4.4.3 | 05.50.70 | OLED | Fully working |
 | OLED65C9AUA | 4.9.x (4.5+) | 05.50.00 | OLED | Fully working |
 | OLED55C1PUB | 6.x (6.3+) | 03.53.45 | OLED | Working (SSH install, MQTT bridge) |
+| OLED65B7V-Z | 3.9.3 | 06.10.65 | OLED | Working, no SoC temperature or eMMC wear |
 
 **If you run it on anything else, please open an issue whether it's working or not**
 Include your model, webOS version and

--- a/docs/IMPLEMENTATION.md
+++ b/docs/IMPLEMENTATION.md
@@ -92,6 +92,12 @@ instead:
 
 **Do not read `/proc/lg/pm/ts_enable`** — it segfaults the reading process.
 
+webOS 3.9 has no temperature source at all: `/proc/lg/pm/temperature` is absent,
+nothing under `/proc/lg` or `/sys` is named for temperature, `/sys/class/thermal` is
+empty, there is no `hwmon`, and `systemproperty` rejects every temperature key. The
+server reports this as `capabilities.thermal: false` so the dashboard can distinguish
+it from the ~80s post-boot window where the file exists but reads 0.
+
 ### /proc/stat is not monotonic
 
 LG hot-plugs CPU cores (`/proc/lg/pm/mp_enable`), so the aggregate counters in

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -235,7 +235,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <section class="hero" style="margin-top:0">
         <div>
           <div class="lbl" style="margin-bottom:14px">SoC</div>
-          <div class="big num"><span id="temp">--</span><span class="deg">&deg;</span></div>
+          <div class="big num"><span id="temp">--</span><span class="deg" id="degsym">&deg;</span></div>
         </div>
         <div class="side">
           <div class="trace" id="trace"></div>
@@ -655,15 +655,27 @@ async function tick() {
       pic.mode ? esc(pic.mode) : ''
     ].filter(Boolean).join('  ·  ');
 
-    // null while the sensor warms up after a reboot - show a dash, not a zero
-    q('temp').textContent = (d.temp === null || d.temp === undefined) ? '--' : d.temp;
-    if (d.temp) document.documentElement.style.setProperty('--hot', thermal(d.temp));
-    // Seed from the server's ring buffer on first paint so the trace says
-    // something immediately, then track locally at the UI's own cadence.
-    if (!hist.length && Array.isArray(d.temps) && d.temps.length) hist = d.temps.slice(-240);
-    else { hist.push(d.temp); if (hist.length > 240) hist.shift(); }
+    // temp is null in two different situations: the sensor is warming up
+    // (~80s after boot, file exists but reads 0), or the platform has no
+    // thermal sensor at all (webOS 3.x - no /proc/lg/pm/temperature, empty
+    // /sys/class/thermal, no hwmon). capabilities.thermal separates them.
+    // Never push null into hist: Math.min/max coerce it to 0, which is where
+    // the old "MIN 0 MAX 0" came from on sensorless sets.
+    const noThermal = !!(d.capabilities && d.capabilities.thermal === false);
+    const hasTemp = !(d.temp === null || d.temp === undefined);
+    q('temp').textContent = hasTemp ? d.temp : '--';
+    q('degsym').hidden = !hasTemp;
+    if (hasTemp) {
+      document.documentElement.style.setProperty('--hot', thermal(d.temp));
+      // Seed from the server's ring buffer on first paint so the trace says
+      // something immediately, then track locally at the UI's own cadence.
+      if (!hist.length && Array.isArray(d.temps) && d.temps.length) hist = d.temps.slice(-240);
+      else { hist.push(d.temp); if (hist.length > 240) hist.shift(); }
+    }
     trace(hist);
-    q('trange').textContent = 'MIN ' + Math.min(...hist) + '   MAX ' + Math.max(...hist);
+    q('trange').textContent = noThermal ? 'NO THERMAL SENSOR'
+      : hist.length ? ('MIN ' + Math.min(...hist) + '   MAX ' + Math.max(...hist))
+      : 'WARMING UP';
     q('mhz').textContent = d.mhz + ' MHZ';
 
     const cores = (d.cores || []).map((c, i) => 'c' + i + ' ' + c).join('   ');

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -12,6 +12,7 @@
 
 var http = require('http');
 var fs = require('fs');
+var THERMAL_PRESENT = fs.existsSync('/proc/lg/pm/temperature');
 var url = require('url');
 var net = require('net');
 var tls = require('tls');
@@ -824,7 +825,12 @@ function collectStats(cb) {
                   }
                 };
                 detectOled(function (oledPanel) {
-                  out.capabilities = { oled: oledPanel };
+                  /* webOS 3.x exposes no thermal sensor at all: the file simply
+                     does not exist, /sys/class/thermal is empty and there is no
+                     hwmon. That is different from the ~80s post-boot window where
+                     the file exists but reads 0, so report it as a capability and
+                     let the UI say "none" rather than imply a pending reading. */
+                  out.capabilities = { oled: oledPanel, thermal: THERMAL_PRESENT };
                   if (!oledPanel) {
                     out.oled = null;
                     return flushStats(out);
@@ -1904,7 +1910,7 @@ var PAGE = [
   '        SoC Temperature',
   '      </div>',
   '    </div>',
-  '    <div class="val"><span id="temp">-</span> <span class="val-unit">&deg;C</span></div>',
+  '    <div class="val"><span id="temp">-</span> <span class="val-unit" id="tempunit">&deg;C</span></div>',
   '    <div class="progress-bar"><div class="progress-fill" id="tempbar"></div></div>',
   '    <div class="meta-text" id="tempmeta">-</div>',
   '  </div>',
@@ -2182,16 +2188,26 @@ var PAGE = [
   '    q("audiometa").textContent = d.muted ? "Muted (press Unmute to restore)" : "Volume level: " + d.volume + "%";',
   '    q("btn_mute").textContent = d.muted ? "Unmute" : "Mute";',
   '',
-  '    // Temperature',
-  '    const temp = d.temp || 0;',
-  '    q("temp").textContent = temp;',
-  '    tempHistory.push(temp);',
-  '    if (tempHistory.length > 100) tempHistory.shift();',
-  '    const minT = Math.min(...tempHistory);',
-  '    const maxT = Math.max(...tempHistory);',
-  '    const tempCol = temp >= 75 ? "var(--rose)" : temp >= 65 ? "var(--amber)" : "var(--emerald)";',
-  '    setProgress("tempbar", temp, tempCol);',
-  '    q("tempmeta").textContent = "Range: " + minT + "°C – " + maxT + "°C (Healthy < 75°C)";',
+  '    // Never push a null temp into the ring: Math.min/max coerce it to 0,',
+  '    // which renders a plausible 0 C on a set that has no sensor at all.',
+  '    const noThermal = !!(d.capabilities && d.capabilities.thermal === false);',
+  '    const hasTemp = !(d.temp === null || d.temp === undefined);',
+  '    const tu = q("tempunit"); if (tu) tu.hidden = !hasTemp;',
+  '    if (hasTemp) {',
+  '      const temp = Number(d.temp);',
+  '      q("temp").textContent = temp;',
+  '      tempHistory.push(temp);',
+  '      if (tempHistory.length > 100) tempHistory.shift();',
+  '      const minT = Math.min(...tempHistory);',
+  '      const maxT = Math.max(...tempHistory);',
+  '      const tempCol = temp >= 75 ? "var(--rose)" : temp >= 65 ? "var(--amber)" : "var(--emerald)";',
+  '      setProgress("tempbar", temp, tempCol);',
+  '      q("tempmeta").textContent = "Range: " + minT + "°C – " + maxT + "°C (Healthy < 75°C)";',
+  '    } else {',
+  '      q("temp").textContent = "n/a";',
+  '      setProgress("tempbar", 0, "var(--muted)");',
+  '      q("tempmeta").textContent = noThermal ? "No thermal sensor on this platform" : "Sensor warming up";',
+  '    }',
   '',
   '    // CPU & Power',
   '    const cpuLoad = d.load || 0;',


### PR DESCRIPTION
webOS 3.9 has no temperature source: `/proc/lg/pm/temperature` is absent, `/sys/class/thermal` is empty and there is no `hwmon`. The server already returned null for `temp`, but both dashboards pushed that null into the history ring, where `Math.min`/`max` coerce it to 0, so a sensorless set showed a 0 °C reading and a permanent "MIN 0 MAX 0".

The server now reports `capabilities.thermal`, which separates a platform with no sensor from the ~80s post-boot window where the file exists but reads 0. The asset dashboard and the embedded fallback both show "no thermal sensor" or "warming up" accordingly, and hide the degree glyph when there is no reading.

Adds OLED65B7V-Z (webOS 3.9.3, firmware 06.10.65) to the tested-on table. Panel hours, compensation and Pixel Refresher counters, CPU load, AVS currents, memory and zram swap all report correctly on it.

One related gap, left alone here in case you would rather handle it separately: `/sys/block/mmcblk0/device/life_time` and `pre_eol_info` are also absent on 3.9, and `emmcInfo()` falls back to `health: ">90% (Healthy)"`, `eol: "Normal"` when `life_time` cannot be read. That reports a healthy drive on a set where wear is simply unknown, which is the same shape of problem as the 0 °C reading.