### PR TITLE
Add the OLED55G42LW to the tested table

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ versions and panel types.
 | OLED65C9AUA | 4.9.x (4.5+) | 05.50.00 | OLED |
 | OLED55C1PUB | 6.x (6.3+) | 03.53.45 | OLED |
 | 55UH6030-UC | 3.4.3 | &mdash; | LCD |
+| OLED55G42LW | 24 | 33.31.68 | OLED |
 
 **If you run it on anything else, please open an issue whether it's working or not**
 Include your model, webOS version and


### PR DESCRIPTION
Reported working on a 2024 G4: dashboard, MQTT discovery, mute, toast,
picture_mode, the privacy panel and the OLED panel metrics, installed over SSH
with `--persist`. Rooted with slopbro rather than the Homebrew Channel, which
the install path evidently does not care about.

The webOS column is inferred from the model generation; the report gave the
firmware (33.31.68) but not the platform version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)