### PR TITLE
Say unknown where nothing was measured

### DIFF
--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -89,6 +89,10 @@ header{display:flex;justify-content:space-between;align-items:baseline;gap:24px;
 .hero .big{font-family:'Outfit';font-weight:200;color:var(--hot,#fff);transition:color .8s ease;
   font-size:clamp(96px,20vw,208px);line-height:.82;letter-spacing:-.025em}
 .hero .deg{font-size:.34em;color:var(--w35);vertical-align:super;letter-spacing:0}
+/* Nothing to show. The spectacle is the number, so at 208px an em dash reads
+   as a broken readout rather than an absent one - drop it to the size of an
+   ordinary figure and let the caption say why. */
+.hero .big.none{font-size:clamp(38px,6vw,58px);color:var(--w25)}
 .hero .side{flex:1;min-width:210px;padding-bottom:10px}
 .trace{display:flex;align-items:flex-end;gap:2px;height:46px;margin-bottom:9px}
 .trace i{flex:1;background:var(--w25);min-height:1px;display:block;transition:background .8s ease}
@@ -235,7 +239,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <section class="hero" style="margin-top:0">
         <div>
           <div class="lbl" style="margin-bottom:14px">SoC</div>
-          <div class="big num"><span id="temp">--</span><span class="deg" id="degsym">&deg;</span></div>
+          <div class="big num none" id="tempbig"><span id="temp">&mdash;</span><span class="deg" id="degsym">&deg;</span></div>
         </div>
         <div class="side">
           <div class="trace" id="trace"></div>
@@ -569,7 +573,8 @@ const audioLabel = raw => AUDIO_LABELS[raw] ||
 
 const SLOTS = 56;
 function trace(vals) {
-  if (!vals.length) return;
+  // Empty means there is nothing to draw, not "leave the last drawing up".
+  if (!vals.length) { q('trace').innerHTML = ''; return; }
   const lo = Math.min(...vals), hi = Math.max(...vals), span = (hi - lo) || 1;
   const recent = vals.slice(-SLOTS);
   // Always lay out SLOTS columns, right-aligned, padding the left with empty
@@ -663,8 +668,9 @@ async function tick() {
     // the old "MIN 0 MAX 0" came from on sensorless sets.
     const noThermal = !!(d.capabilities && d.capabilities.thermal === false);
     const hasTemp = !(d.temp === null || d.temp === undefined);
-    q('temp').textContent = hasTemp ? d.temp : '--';
+    q('temp').textContent = hasTemp ? d.temp : '\u2014';
     q('degsym').hidden = !hasTemp;
+    q('tempbig').classList.toggle('none', !hasTemp);
     if (hasTemp) {
       document.documentElement.style.setProperty('--hot', thermal(d.temp));
       // Seed from the server's ring buffer on first paint so the trace says

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -276,8 +276,8 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
     <div class="grp-sec">
       <div class="grp">Storage</div>
       <div class="cols">
-        <div><div class="lbl">Flash wear</div><div class="v num" id="flashval">&mdash;</div><div class="sub">eMMC lifetime estimated</div></div>
-        <div><div class="lbl">Flash health</div><div class="v" id="flasheol">&mdash;</div><div class="sub">Pre-EOL status</div></div>
+        <div id="flashwear-cell"><div class="lbl">Flash wear</div><div class="v num" id="flashval">&mdash;</div><div class="sub">eMMC lifetime estimated</div></div>
+        <div id="flashhealth-cell"><div class="lbl">Flash health</div><div class="v" id="flasheol">&mdash;</div><div class="sub">Pre-EOL status</div></div>
         <div id="appstore-cell" hidden><div class="lbl">App space</div><div class="v num" id="appstore">&mdash;</div><div class="sub" id="appstore-sub"></div></div>
       </div>
     </div>
@@ -572,6 +572,29 @@ const audioLabel = raw => AUDIO_LABELS[raw] ||
            .replace(/^./, ch => ch.toUpperCase()) : '');
 
 const SLOTS = 56;
+/*
+ * A section whose every cell has been hidden - Storage on a set with no wear
+ * counters and no app storage figure - would otherwise render as a heading
+ * over empty space, which reads as a failure rather than an absence.
+ */
+function pruneEmptySections() {
+  document.querySelectorAll('.grp-sec').forEach(function (sec) {
+    const grid = sec.querySelector('.cols');
+    if (!grid) return;
+    const cells = Array.from(grid.children);
+    // Only ever manage sections this function itself hid. #panelblock is
+    // hidden wholesale on a non-OLED set while its cells stay visible, so a
+    // plain assignment here would put it back on screen.
+    if (cells.length > 0 && cells.every(function (c) { return c.hidden; })) {
+      sec.hidden = true;
+      sec.dataset.pruned = '1';
+    } else if (sec.dataset.pruned) {
+      sec.hidden = false;
+      delete sec.dataset.pruned;
+    }
+  });
+}
+
 function trace(vals) {
   // Empty means there is nothing to draw, not "leave the last drawing up".
   if (!vals.length) { q('trace').innerHTML = ''; return; }
@@ -737,9 +760,16 @@ async function tick() {
     q('lux-cell').hidden = !ls_;
     if (ls_) q('lux').textContent = ls_.lux;
 
-    // Flash storage is independent of panel type, so it always renders.
-    q('flashval').textContent = (d.emmc && d.emmc.wear) || '—';
-    q('flasheol').textContent = (d.emmc && d.emmc.health) || (d.emmc && d.emmc.eol) || '—';
+    /* Flash wear is independent of panel type, but the counters do not exist
+       on webOS 3.x - drop the cells rather than print "unknown" twice. */
+    const wear_ = !(d.capabilities && d.capabilities.emmcWear === false);
+    q('flashwear-cell').hidden = !wear_;
+    q('flashhealth-cell').hidden = !wear_;
+    if (wear_) {
+      q('flashval').textContent = (d.emmc && d.emmc.wear) || '—';
+      q('flasheol').textContent = (d.emmc && d.emmc.health) || (d.emmc && d.emmc.eol) || '—';
+    }
+    pruneEmptySections();
 
     muted = !!d.muted;
     q('vol').textContent = muted ? 'MUTED' : d.volume;

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -170,8 +170,13 @@ var EOL_MAP = { '01': 'Normal', '02': 'Warning', '03': 'Urgent' };
 function emmcInfo() {
   var raw = rd('/sys/block/mmcblk0/device/life_time');
   var eolRaw = rd('/sys/block/mmcblk0/device/pre_eol_info');
-  var eol = (eolRaw && EOL_MAP[eolRaw.trim()]) ? EOL_MAP[eolRaw.trim()] : 'Normal';
-  if (!raw) return { life: 'unknown', wear: 'unknown', health: '>90% (Healthy)', eol: eol };
+  /*
+   * Both nodes are absent on webOS 3.x. Reporting a healthy drive because the
+   * wear counter could not be read is the same mistake as rendering 0 C for a
+   * missing thermal sensor: it states as fact something never measured.
+   */
+  var eol = (eolRaw && EOL_MAP[eolRaw.trim()]) || 'unknown';   // 0x00 is "not defined", not Normal
+  if (!raw) return { life: 'unknown', wear: 'unknown', health: 'unknown', eol: eol };
 
   var parts = raw.split(/\s+/), wearList = [], minHealth = 100;
   for (var i = 0; i < parts.length; i++) {
@@ -2279,8 +2284,8 @@ var PAGE = [
   '    q("swapmeta").textContent = "zram Swap: " + formatMb(swapUsed) + " of " + formatMb(swapTotal) + " (" + swapPct + "%)";',
   '',
   '    // Storage & Network',
-  '    q("emmc").textContent = (d.emmc && d.emmc.health) || ">90%";',
-  '    q("emmcmeta").textContent = "Wear: " + ((d.emmc && d.emmc.wear) || "0-10%") + " · EOL Status: " + ((d.emmc && d.emmc.eol) || "Normal");',
+  '    q("emmc").textContent = (d.emmc && d.emmc.health) || "unknown";',
+  '    q("emmcmeta").textContent = "Wear: " + ((d.emmc && d.emmc.wear) || "unknown") + " · EOL Status: " + ((d.emmc && d.emmc.eol) || "unknown");',
   '    const wifiText = d.wifi ? "Wi-Fi: " + d.wifi.level + " dBm (Signal " + d.wifi.link + "%)" : "Ethernet Wired";',
   '    const netText = d.net ? " · ↓ " + (d.net.rx / 1024).toFixed(1) + " KB/s · ↑ " + (d.net.tx / 1024).toFixed(1) + " KB/s" : "";',
   '    q("netmeta").textContent = wifiText + netText;',
@@ -3323,6 +3328,22 @@ function setupHomeAssistant() {
         } else { keptLogo.push(entities[g]); }
       }
       entities = keptLogo;
+    }
+
+    /*
+     * Same reasoning on platforms with no thermal sensor at all (webOS 3.x):
+     * publishing the entity would leave a temperature in Home Assistant that
+     * is permanently unknown, which reads as a broken sensor rather than an
+     * absent one.
+     */
+    if (!THERMAL_PRESENT) {
+      var keptTemp = [];
+      for (var t = 0; t < entities.length; t++) {
+        if (entities[t].id === 'soc_temperature') {
+          mqttClient.publish(discPfx + '/sensor/' + devId + '/soc_temperature/config', '', true);
+        } else { keptTemp.push(entities[t]); }
+      }
+      entities = keptTemp;
     }
 
     if (!hasLightSensor) {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -13,6 +13,7 @@
 var http = require('http');
 var fs = require('fs');
 var THERMAL_PRESENT = fs.existsSync('/proc/lg/pm/temperature');
+var EMMC_WEAR_PRESENT = fs.existsSync('/sys/block/mmcblk0/device/life_time');
 var url = require('url');
 var net = require('net');
 var tls = require('tls');
@@ -872,7 +873,8 @@ function collectStats(cb) {
                      hwmon. That is different from the ~80s post-boot window where
                      the file exists but reads 0, so report it as a capability and
                      let the UI say "none" rather than imply a pending reading. */
-                  out.capabilities = { oled: oledPanel, thermal: THERMAL_PRESENT };
+                  out.capabilities = { oled: oledPanel, thermal: THERMAL_PRESENT,
+                                       emmcWear: EMMC_WEAR_PRESENT };
                   if (!oledPanel) {
                     out.oled = null;
                     return flushStats(out);
@@ -3344,6 +3346,21 @@ function setupHomeAssistant() {
         } else { keptTemp.push(entities[t]); }
       }
       entities = keptTemp;
+    }
+
+    /*
+     * Same again for the eMMC wear counters, absent on webOS 3.x. An entity
+     * reading "unknown" for the life of the install is indistinguishable from
+     * a sensor that has broken.
+     */
+    if (!EMMC_WEAR_PRESENT) {
+      var keptFlash = [];
+      for (var f = 0; f < entities.length; f++) {
+        if (entities[f].id === 'flash_health' || entities[f].id === 'flash_wear') {
+          mqttClient.publish(discPfx + '/sensor/' + devId + '/' + entities[f].id + '/config', '', true);
+        } else { keptFlash.push(entities[f]); }
+      }
+      entities = keptFlash;
     }
 
     if (!hasLightSensor) {


### PR DESCRIPTION
Follow-ups to #15, which stopped a missing thermal sensor rendering as 0 °C.
The same shape of problem turned up in three more places: readings that state
as fact something the platform never measured.

**Home Assistant.** #15 fixed both dashboards but not the MQTT side, so a set
with no thermal sensor still got a `soc_temperature` entity sitting at unknown
forever. The eMMC `flash_health` and `flash_wear` entities did the same where
the wear counters do not exist. All three are now withheld with their retained
configs cleared, as the ambient light and OLED-only entities already were. An
entity permanently reading unknown cannot be told from one that has broken.

**eMMC.** `emmcInfo()` returned `health: '>90% (Healthy)'` and `eol: 'Normal'`
when `life_time` and `pre_eol_info` could not be read at all — a healthy
verdict on a drive nobody measured. Both report unknown now, including a
`pre_eol_info` outside the spec's `0x01`–`0x03`, since `0x00` means "not
defined". The fallback page's own `|| ">90%"` and `|| "Normal"` defaults told
the same story and are gone.

**The dashboard.** The Storage cells are dropped rather than printing
"unknown" twice, which can empty that section entirely on a set with no app
storage figure either — so a section whose cells have all gone is dropped too,
rather than leaving a heading over blank space. The pruning only ever hides
sections it hid itself: the panel block is hidden wholesale on a non-OLED set
while its cells stay visible, and a plain assignment put it back on screen
until that was fixed.

**The hero.** With no reading the dash rendered at the full 208px, which looks
like a broken number rather than an absent one. It drops to the size of an
ordinary figure, and the trace clears rather than leaving the last drawing up.

## Verified

On the B8, where every one of these nodes is readable: `capabilities` reports
`oled/thermal/emmcWear` all true, eMMC still `0-10% / 0-10%`, `>90% (Healthy)`,
`Normal`, still 47 discovery entities, and the hero and Storage section are
unchanged.

The absent-hardware paths were driven by serving the dashboard stubbed
payloads, since none of us has a webOS 3.x set:

| capabilities | Storage section | Flash cells | App space | Panel block |
| :--- | :--- | :--- | :--- | :--- |
| all present | shown | shown | shown | shown |
| no wear counters | shown | hidden | shown | shown |
| no wear, no app storage | hidden | hidden | hidden | shown |
| non-OLED, neither | hidden | hidden | hidden | hidden |

🤖 Generated with [Claude Code](https://claude.com/claude-code)