### PR TITLE
Do not restart the server just because the TV was asleep

### DIFF
--- a/server/tvwebctl
+++ b/server/tvwebctl
@@ -62,8 +62,25 @@ start_watch() {
 # An absent heartbeat is deliberately NOT a fault: a server predating the
 # heartbeat, or one still starting up, would otherwise be restarted forever.
 watch_loop() {
+  last=$(date +%s)
   while true; do
     sleep "$CHECK"
+
+    #
+    # Standby suspends this loop along with everything else, so on resume the
+    # heartbeat is stale because the whole TV stopped - not because the server
+    # wedged. The tell is that far more time passed than was slept for: a real
+    # wedge is caught inside two checks, because the watchdog itself keeps
+    # running. Give the server one round to write a beat before judging it.
+    #
+    now=$(date +%s)
+    slept=$(( now - last ))
+    last=$now
+    if [ "$slept" -gt $(( CHECK * 3 )) ]; then
+      echo "$(date): resumed after ${slept}s suspended - skipping one check" >> "$LOG"
+      continue
+    fi
+
     [ -f "$PIDFILE" ] || continue                     # stopped on purpose
     if ! kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
       echo "$(date): process gone - starting" >> "$RESTARTS"


### PR DESCRIPTION
The watchdog added in #17 restarts the server when its heartbeat goes stale.
Standby suspends the watchdog too, so on resume it sees a heartbeat that
stopped when the whole TV did and restarts a server that was never broken.

This happened on the B8 at 16:29 today, alongside a SIGSTOP test from earlier:

```
13:42:34: heartbeat 119s old - event loop wedged, restarting   ← real wedge, caught in two checks
16:29:29: heartbeat 543s old - event loop wedged, restarting   ← standby, nothing was wrong
```

The two ages are the tell. A real wedge is caught inside two checks because the
watchdog keeps running; a suspend shows a far larger age because the watchdog
missed those checks as well. So it now times its own loop, and when far more
time has passed than it slept for, gives the server one round to write a beat
before judging it.

## Verified on the B8

Freezing both processes and resuming only the watchdog reproduces exactly the
resume ordering that standby produces:

```
16:40:37: resumed after 147s suspended - skipping one check   ← no restart, server left alone
16:41:07: heartbeat 167s old - event loop wedged, restarting  ← still frozen, so caught anyway
```

The grace is one round and one round only: the server stayed untouched on the
first check and was restarted 30s later when the heartbeat was still stale.
Dashboard back to 200 afterwards.

Worth noting the obvious simulation trap: SIGSTOP/SIGCONT on both processes at
once does *not* reproduce this, because SIGCONT makes node fire its timers
immediately and the heartbeat is fresh before the watchdog ever looks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)