### PR TITLE
Make the small readings legible

### DIFF
--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -35,6 +35,10 @@
   --w35:rgba(255,255,255,.35); --w50:rgba(255,255,255,.50);
   --w60:rgba(255,255,255,.60); --w80:rgba(255,255,255,.80);
   --w100:#fff;
+  /* Contrast on black: w25 is 2.0:1, w35 is 3.0:1, w50 is 5.3:1, w60 is 7.4:1.
+     Only w50 and above may carry text - w60 where it is under ~13px, since the
+     4.5:1 floor applies to anything that is not large. The steps below w50 are
+     for rules, borders and fills. */
   /* Accents, taken from the Velo light-scene swatches (Nanoleaf/Hue/LIFX).
      Used to carry meaning only - thermal state, headroom, signal format -
      never as decoration. The chrome stays monochrome. */
@@ -88,11 +92,11 @@ header{display:flex;justify-content:space-between;align-items:baseline;gap:24px;
 .hero{margin:clamp(20px,4vw,34px) 0 0;display:flex;align-items:flex-end;justify-content:space-between;gap:32px;flex-wrap:wrap}
 .hero .big{font-family:'Outfit';font-weight:200;color:var(--hot,#fff);transition:color .8s ease;
   font-size:clamp(96px,20vw,208px);line-height:.82;letter-spacing:-.025em}
-.hero .deg{font-size:.34em;color:var(--w35);vertical-align:super;letter-spacing:0}
+.hero .deg{font-size:.34em;color:var(--w50);vertical-align:super;letter-spacing:0}
 /* Nothing to show. The spectacle is the number, so at 208px an em dash reads
    as a broken readout rather than an absent one - drop it to the size of an
    ordinary figure and let the caption say why. */
-.hero .big.none{font-size:clamp(38px,6vw,58px);color:var(--w25)}
+.hero .big.none{font-size:clamp(38px,6vw,58px);color:var(--w50)}
 .hero .side{flex:1;min-width:210px;padding-bottom:10px}
 .trace{display:flex;align-items:flex-end;gap:2px;height:46px;margin-bottom:9px}
 .trace i{flex:1;background:var(--w25);min-height:1px;display:block;transition:background .8s ease}
@@ -103,7 +107,7 @@ header{display:flex;justify-content:space-between;align-items:baseline;gap:24px;
 
 /* ---- readouts ---- */
 .readouts{margin-top:0;border-top:1px solid var(--w06)}
-.r{display:grid;grid-template-columns:clamp(118px,17%,176px) 1fr 92px;gap:20px;align-items:center;
+.r{display:grid;grid-template-columns:clamp(144px,17%,176px) 1fr 92px;gap:20px;align-items:center;
    padding:15px 0;border-bottom:1px solid var(--w06)}
 .r .v{font-family:'Outfit';font-weight:200;font-size:26px;color:var(--w100);text-align:right;line-height:1}
 .r .v small{font-size:13px;color:var(--w50);margin-left:4px;font-family:'Manrope';font-weight:400}
@@ -225,19 +229,19 @@ button[disabled]:hover{color:var(--w60);border-color:var(--w12)}
   display:flex;flex-direction:column;min-height:112px}
 .port .ptop{display:flex;align-items:flex-start;justify-content:space-between;gap:10px}
 .port .pn{font-family:'Outfit';font-weight:200;font-size:38px;line-height:.9;
-  color:var(--w25);font-variant-numeric:tabular-nums}
-.port .pst{font-size:10.5px;letter-spacing:.13em;text-transform:uppercase;color:var(--w35);
+  color:var(--w50);font-variant-numeric:tabular-nums}
+.port .pst{font-size:10.5px;letter-spacing:.13em;text-transform:uppercase;color:var(--w60);
   padding-top:4px;white-space:nowrap}
 .port .pl{font-size:14px;color:var(--w50);margin-top:auto;
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.port .pd{font-size:12px;color:var(--w35);margin-top:2px;
+.port .pd{font-size:12px;color:var(--w60);margin-top:2px;
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 /* Nothing plugged in: the number alone. The dashed edge carries "empty", so
    the numeral keeps its normal weight - it is the only thing in the tile, and
    dimming it further would make the one piece of information unreadable. */
 .port.empty{border-color:var(--w06);border-style:dashed}
 .port.seen{border-color:var(--w10)}
-.port.seen .pn{color:var(--w50)}
+.port.seen .pn{color:var(--w80)}
 .port.seen .pl{color:var(--w80)}
 .port.live{border-color:var(--w25);background:var(--w06)}
 .port.live .pn{color:var(--w100)}
@@ -754,7 +758,10 @@ async function tick() {
       : 'WARMING UP';
     q('mhz').textContent = d.mhz + ' MHZ';
 
-    const cores = (d.cores || []).map((c, i) => 'c' + i + ' ' + c).join('   ');
+    /* The core figures are positional, so the c0/c1 prefixes were four
+       redundant labels competing for a 132px column - at three digits each the
+       last core was being ellipsised away exactly when the TV was busy. */
+    const cores = (d.cores || []).join('  ·  ');
     row('cpu', d.load + '<small>%</small>', d.load, cores, 85);
 
     const mu = d.mem.total ? 100 * (d.mem.total - d.mem.avail) / d.mem.total : 0;
@@ -770,7 +777,7 @@ async function tick() {
     q('row-draw').hidden = !(d.power && d.power.current_ma);
     const rx = d.net ? (d.net.rx / 1024) : 0, tx = d.net ? (d.net.tx / 1024) : 0;
     row('net', rx.toFixed(0) + '<small>kB/s</small>', Math.min(100, rx / 20),
-        (d.wifi ? d.wifi.level + ' dBm   ' : '') + 'up ' + tx.toFixed(0) + ' kB/s', 101);
+        (d.wifi ? d.wifi.level + ' dBm  ·  ' : '') + tx.toFixed(0) + ' up', 101);
 
     const ma = (d.power && d.power.current_ma) || 0;
     row('draw', ma + '<small>mA</small>', Math.min(100, ma / 4),

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -192,7 +192,18 @@ function emmcInfo() {
       if (rem < minHealth) minHealth = rem;
     }
   }
-  var wearStr = wearList.length ? wearList.join(' / ') : '0-10%';
+  /*
+   * The controller reports a band per region, and on a healthy drive they are
+   * all the same - "0-10% / 0-10%" is one fact stated twice, and it wrapped to
+   * two lines in the dashboard's cell. Collapse them when they agree; a drive
+   * whose regions have diverged still shows every band, which is the case
+   * where the detail earns its space.
+   */
+  var uniqWear = [];
+  for (var u = 0; u < wearList.length; u++) {
+    if (uniqWear.indexOf(wearList[u]) === -1) uniqWear.push(wearList[u]);
+  }
+  var wearStr = uniqWear.length ? uniqWear.join(' / ') : '0-10%';
   var healthStr = (minHealth >= 90) ? '>90% (Healthy)' : (minHealth + '% remaining');
   return {
     life: wearStr,    // backwards-compatible with old HA discovery template


### PR DESCRIPTION
Three findings from measuring the rendered page rather than reading the CSS.

## Contrast

The palette's lower steps were carrying text. Measured on black:

| token | contrast | was used for |
| :--- | ---: | :--- |
| `--w25` | 2.03:1 | an empty HDMI port's numeral — the only content in that tile |
| `--w35` | 3.00:1 | an idle port's state tag at 10.5px, and its detail line at 12px |
| `--w50` | 5.32:1 | labels |
| `--w60` | 7.37:1 | captions |

Normal text needs 4.5:1 and large text 3:1, so both of those failed — the
2.03:1 case worst of all, since nothing else was in the tile to read. Anything
carrying text is now `w50` or above, and `w60` below about 13px. The rule is
written next to the palette so the next person does not have to re-derive it.

This corrects a judgement made when the port grid was built: the empty
numerals were dimmed for contrast against the live tile, on the reasoning that
the dashed border carried the meaning. The border does carry the meaning, but
the numeral is still the only information there.

## Per-core figures were cut when they mattered

The label column was 132px; `c0 100 c1 100 c2 100 c3 100` needs 166px, so the
fourth core was ellipsised away exactly when the TV was busy enough to produce
three-digit values. The `c0`/`c1` prefixes were four redundant labels on
positional figures. `9 · 5 · 6 · 0` reads the same and the worst case is now
114px against a 144px column — 30px of headroom, which the old layout was 48px
short of. The network line got the same treatment.

## Flash wear stated one fact twice

The controller reports a wear band per region, and a healthy drive reports the
same band for both — `0-10% / 0-10%`, which wrapped to two lines in its cell.
Identical bands collapse to one; a drive whose regions have diverged still
shows each band, which is the case where the detail is worth the space. Fixed
in `emmcInfo()` so the Home Assistant sensor reads the same way.

Verified on the B8 against the live page: worst-case strings measured with a
font-matched probe rather than `scrollWidth`, which cannot report narrower than
the element and hid the real headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)