### PR TITLE
Stop reporting the eMMC wear band twice

### DIFF
--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -326,7 +326,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="grp">Storage</div>
       <div class="cols">
         <div id="flashwear-cell"><div class="lbl">Flash wear</div><div class="v num" id="flashval">&mdash;</div><div class="sub">eMMC lifetime estimated</div></div>
-        <div id="flashhealth-cell"><div class="lbl">Flash health</div><div class="v" id="flasheol">&mdash;</div><div class="sub">Pre-EOL status</div></div>
+        <div id="flashhealth-cell"><div class="lbl">Pre-EOL status</div><div class="v" id="flasheol">&mdash;</div><div class="sub">Drive's own assessment</div></div>
         <div id="appstore-cell" hidden><div class="lbl">App space</div><div class="v num" id="appstore">&mdash;</div><div class="sub" id="appstore-sub"></div></div>
       </div>
     </div>
@@ -826,7 +826,10 @@ async function tick() {
     q('flashhealth-cell').hidden = !wear_;
     if (wear_) {
       q('flashval').textContent = (d.emmc && d.emmc.wear) || '—';
-      q('flasheol').textContent = (d.emmc && d.emmc.health) || (d.emmc && d.emmc.eol) || '—';
+      /* emmc.health is the wear band inverted - the same register, arithmetic
+         the other way up - so showing both said one thing twice. pre_eol_info
+         is a separate register and the only one that can warn on its own. */
+      q('flasheol').textContent = (d.emmc && d.emmc.eol) || '—';
     }
     pruneEmptySections();
 

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -204,6 +204,8 @@ function emmcInfo() {
     if (uniqWear.indexOf(wearList[u]) === -1) uniqWear.push(wearList[u]);
   }
   var wearStr = uniqWear.length ? uniqWear.join(' / ') : '0-10%';
+  // The wear band inverted. Kept for anyone templating on it; nothing in this
+  // project presents it, because next to `wear` it is the same fact twice.
   var healthStr = (minHealth >= 90) ? '>90% (Healthy)' : (minHealth + '% remaining');
   return {
     life: wearStr,    // backwards-compatible with old HA discovery template
@@ -2927,7 +2929,11 @@ function setupHomeAssistant() {
         payload: {
           name: 'Flash Storage Health',
           state_topic: telemetryTopic,
-          value_template: '{{ value_json.emmc.health }}',
+          /* pre_eol_info, not the inverted wear band: emmc.health is derived
+             from the same register as emmc.wear, so the two sensors were
+             reporting one number twice. The name still fits - Normal, Warning
+             and Urgent are exactly a health status. */
+          value_template: '{{ value_json.emmc.eol }}',
           icon: 'mdi:harddisk'
         }
       },


### PR DESCRIPTION
Flash wear and Flash health are one register read twice. `emmcInfo()` derives the
band from `life_time`, then computes health as 100 minus it:

```
wear   = "0-10%"            <- life_time
health = ">90% (Healthy)"   <- 100 minus that, same register
eol    = "Normal"           <- pre_eol_info, a different register
```

So the dashboard had two Storage cells and Home Assistant two sensors for one
number, while `pre_eol_info` — the only eMMC reading that can raise a warning on
its own, independent of the wear counter — was squeezed out.

It was worse than redundant. The second cell was captioned **Pre-EOL status** but
filled with the inverted wear band:

```js
q('flasheol').textContent = (d.emmc && d.emmc.health) || (d.emmc && d.emmc.eol) || '—';
```

falling back to the pre-EOL value only if health was missing. The element id
`flasheol` is a fossil of when it did show it. So the caption described the
fallback rather than what was on screen.

Now: `Flash wear` shows the band, `Pre-EOL status` shows `pre_eol_info`.

The Home Assistant `flash_health` sensor points at `pre_eol_info` too. Its name
still fits — Normal, Warning and Urgent are exactly a health status — so the
entity id does not churn, but **its values change** from `>90% (Healthy)` to
`Normal` / `Warning` / `Urgent`, which mixes any history on that sensor.

`emmc.health` stays in the API for anyone templating on it, with a comment saying
what it duplicates.

Verified on the B8: wear `0-10%`, pre-EOL `Normal`, and the retained discovery
config now templates `{{ value_json.emmc.eol }}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)