### PR TITLE
Label the Personalized picture mode

### DIFF
--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -272,6 +272,7 @@ var PIC_MODE_MAP = {
   hdrStandard: 'HDR Standard',
   hdrGame: 'HDR Game',
   cinema: 'Cinema',
+  personalized: 'Personalized',   // reported by webOS 22 sets
   expert1: 'ISF Expert (Bright)',
   expert2: 'ISF Expert (Dark)',
   game: 'Game',


### PR DESCRIPTION
webOS 22 sets report `personalized` - the picture mode that adapts to the viewer - and `PIC_MODE_MAP` had no entry for it, so `formatPicMode` fell through to the raw value and the mode showed as "personalized" where every other mode reads as a label.