### PR TITLE
Report the tvweb version over MQTT and on the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A telemetry server that runs **on** a rooted LG webOS TV. It serves a live
 dashboard to any browser on your network, and bridges the TV into Home
-Assistant over MQTT as a single auto-discovered device with 47 entities.
+Assistant over MQTT as a single auto-discovered device with 48 entities.
 
 There are no dependencies. This is ES5 on the Node 0.12 runtime that is on the TV.
 
@@ -22,7 +22,7 @@ though something is playing.
 
 ### Home Assistant (Auto-Discovered Device via MQTT)
 
-All 47 entities arrive over MQTT Discovery as a single device
+All 48 entities arrive over MQTT Discovery as a single device
 <p align="center">
 <img width="1061" height="1042" alt="image" src="https://github.com/user-attachments/assets/1d76b1a2-68d9-42a4-a497-b107d706b235" />
 </p>
@@ -220,7 +220,7 @@ Full detail, including the MQTT ACL guidance and optional TLS, is in
 ## Documentation
 
 * [docs/SECURITY.md](docs/SECURITY.md) &mdash; threat model, SSH migration, MQTT hardening
-* [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) &mdash; all 47 entities, universal media player, example automations
+* [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) &mdash; all 48 entities, universal media player, example automations
 * [docs/IMPLEMENTATION.md](docs/IMPLEMENTATION.md) &mdash; architecture, `/proc/lg` reference, platform quirks
 
 ---

--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -6,7 +6,7 @@ Entity reference and example automations.
 
 ## Entities
 
-Once connected to your MQTT broker, Home Assistant automatically discovers **41 native entities** under a single unified device:
+Once connected to your MQTT broker, Home Assistant automatically discovers **42 native entities** under a single unified device:
 
 | Domain | Entity ID | Name | Description |
 | :--- | :--- | :--- | :--- |
@@ -51,6 +51,7 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **41 
 | `sensor` | `sensor.lg_tv_flash_health` | Flash Storage Health | eMMC remaining health estimate (`>90% (Healthy)`) |
 | `sensor` | `sensor.lg_tv_flash_wear` | Flash Wear Level | JEDEC write-cycle consumption (`0–10%`) |
 | `sensor` | `sensor.lg_tv_uptime` | Uptime | TV uptime in seconds |
+| `sensor` | `sensor.lg_tv_tvweb_version` | tvweb Version | Version of tvweb itself, not the TV firmware (diagnostic) |
 
 ---
 

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -256,6 +256,10 @@ button[disabled]:hover{color:var(--w60);border-color:var(--w12)}
 #err{margin-top:18px;font-size:14px;color:var(--red);border-left:2px solid var(--red);padding:9px 13px;background:var(--w06);display:none}
 @media (max-width:620px){.src{text-align:left}.hero{gap:22px}}
 footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:uppercase;color:var(--w50);display:flex;justify-content:space-between;gap:16px;flex-wrap:wrap}
+/* The separator rides on the link so both appear only once a version is known. */
+#version{text-transform:none;color:inherit;text-decoration:none}
+#version::before{content:'|';margin:0 .55em;opacity:.45}
+#version:hover{color:var(--w80);text-decoration:underline}
 .stale{opacity:.35;transition:opacity .3s}
 </style>
 </head>
@@ -507,7 +511,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
 
 <footer>
   <span id="uptime">&mdash;</span>
-  <span id="clock">&mdash;</span>
+  <span><span id="clock">&mdash;</span><a id="version" hidden target="_blank" rel="noopener noreferrer"></a></span>
 </footer>
 
 <script>
@@ -908,10 +912,23 @@ async function tick() {
     const up = d.uptime, dd = Math.floor(up / 86400), hh = Math.floor(up % 86400 / 3600), mm = Math.floor(up % 3600 / 60);
     q('uptime').textContent = 'Up ' + (dd ? dd + 'd ' : '') + hh + 'h ' + mm + 'm   ·   load ' + (d.loadavg || []).join(' ');
     q('clock').textContent = new Date().toLocaleTimeString();
+    setVersion(d.tvwebVersion);
   } catch (e) {
     document.body.classList.add('stale');
     if (Date.now() - lastOk > 6000) showErr(e.message || 'TV unreachable');
   }
+}
+
+// Releases are cut on the upstream repo, so the tag link points there.
+const REPO = 'https://github.com/rorygallagher2024/lg-webos-mqtt';
+
+function setVersion(v) {
+  const el = q('version');
+  if (!v || el.dataset.v === v) return;   // static between restarts, so set it once
+  el.dataset.v = v;
+  el.textContent = 'v' + v;
+  el.href = REPO + '/releases/tag/v' + v;
+  el.hidden = false;
 }
 
 function showErr(m) { const e = q('err'); e.textContent = m; e.style.display = 'block'; }

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -21,6 +21,13 @@ var child_process = require('child_process');
 var path = require('path');
 var execFile = child_process.execFile;
 
+/*
+ * Bump on release, and tag the release to match: the dashboard turns this into
+ * a link to /releases/tag/v<version>, so a value with no tag behind it gives a
+ * 404 rather than a wrong page.
+ */
+var TVWEB_VERSION = '0.9.0';
+
 // ---------------------------------------------------------------- config
 var CONFIG = {
   // The dashboard. Turn this off if you drive everything from Home Assistant:
@@ -862,6 +869,7 @@ function collectStats(cb) {
   var out = {
     ok: true,
     time: Date.now(),
+    tvwebVersion: TVWEB_VERSION,
     device: {
       id: CONFIG.device.id || 'lg_tv',
       name: CONFIG.device.name || 'LG webOS TV',
@@ -3163,6 +3171,22 @@ function setupHomeAssistant() {
           unit_of_measurement: 's',
           device_class: 'duration',
           icon: 'mdi:clock-outline'
+        }
+      },
+      {
+        /*
+         * tvweb's own version, not the TV's - the device's sw_version already
+         * carries the firmware. Named for the program so the two cannot be
+         * read as each other on a device page that shows both. Diagnostic: it
+         * belongs beside the firmware, not among the readings.
+         */
+        type: 'sensor', id: 'tvweb_version',
+        payload: {
+          name: 'tvweb Version',
+          state_topic: telemetryTopic,
+          value_template: '{{ value_json.tvwebVersion }}',
+          entity_category: 'diagnostic',
+          icon: 'mdi:tag-outline'
         }
       },
       {


### PR DESCRIPTION
Neither the dashboard nor Home Assistant said which build was running, so there was no way to tell a TV that had been updated from one that had not.

`TVWEB_VERSION` is the single source. It goes into the stats payload, which the dashboard and the MQTT telemetry already both read, so one field covers both.

The entity, the telemetry field and the label are all named for the program - `sensor.<device>_tvweb_version`, `tvwebVersion`, "tvweb Version" - because the device page shows this alongside the TV's own firmware and the two must not read as each other. `sw_version` stays the firmware. The entity is diagnostic, so it sits beside the firmware rather than among the readings.

The dashboard footer puts it after the clock as a link to that tag's release page - `12:37:23 PM | v0.9.0`.

The constant is bumped by hand at release time and the tag has to match, or the link 404s.