### PR TITLE
Capitalise the version entity as TVWeb Version

### DIFF
--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -51,7 +51,7 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **42 
 | `sensor` | `sensor.lg_tv_flash_health` | Flash Storage Health | eMMC remaining health estimate (`>90% (Healthy)`) |
 | `sensor` | `sensor.lg_tv_flash_wear` | Flash Wear Level | JEDEC write-cycle consumption (`0–10%`) |
 | `sensor` | `sensor.lg_tv_uptime` | Uptime | TV uptime in seconds |
-| `sensor` | `sensor.lg_tv_tvweb_version` | tvweb Version | Version of tvweb itself, not the TV firmware (diagnostic) |
+| `sensor` | `sensor.lg_tv_tvweb_version` | TVWeb Version | Version of tvweb itself, not the TV firmware (diagnostic) |
 
 ---
 

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -3199,7 +3199,7 @@ function setupHomeAssistant() {
          */
         type: 'sensor', id: 'tvweb_version',
         payload: {
-          name: 'tvweb Version',
+          name: 'TVWeb Version',
           state_topic: telemetryTopic,
           value_template: '{{ value_json.tvwebVersion }}',
           entity_category: 'diagnostic',


### PR DESCRIPTION
Only the display label changes. The entity id stays `tvweb_version`, so existing installs keep their entity and pick the new name up on the next discovery publish.