### PR TITLE
Stop the System section pruning its own readouts

### DIFF
--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -664,7 +664,14 @@ function pruneEmptySections() {
   document.querySelectorAll('.grp-sec').forEach(function (sec) {
     const grid = sec.querySelector('.cols');
     if (!grid) return;
-    const cells = Array.from(grid.children);
+    /*
+     * Readout rows count as content too. System puts them above its cell grid,
+     * and a set that reports neither a GPU clock nor an SSID - webOS 9+ on a
+     * wired connection - hides both of those cells, which pruned processor,
+     * memory, swap, network and current off the page along with them.
+     */
+    const cells = Array.from(grid.children)
+      .concat(Array.from(sec.querySelectorAll('.readouts .r')));
     // Only ever manage sections this function itself hid. #panelblock is
     // hidden wholesale on a non-OLED set while its cells stay visible, so a
     // plain assignment here would put it back on screen.


### PR DESCRIPTION
`pruneEmptySections()` judges a section by its cell grid alone, so a heading does not float over empty space. System keeps its readout rows *above* that grid, and its grid holds only the GPU-clock and SSID cells.

A set that reports neither - webOS 9+ on a wired connection, where `gpuMhz` and `ssid` are both null - hides both cells, the section is judged empty, and processor, memory, swap, network and current go off the page with them. No error, so it reads as deliberate.

Readout rows now count as content, so a section prunes only when it is genuinely empty. Storage on a set with no wear counter and no app-storage figure still prunes as before.

Verified on an OLED55G42LW (webOS 9+, wired): the five readouts are back, and the values match `/api/stats`.