### PR TITLE
Fix four readings that were wrong on webOS 9+ and wired sets, and show data totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bind-mounting over `/etc/hosts` that persists across reboots.
   mode, OLED light level, raw HDMI signal (`3840x2160 @ 60Hz`), audio output
   routing, and active app with friendly input names (`Apple TV (HDMI2)`).
 * **Hardware diagnostics.** SoC temperature and current draw, CPU and per-core
-  load, GPU clock, memory and zram swap, Wi-Fi RSSI, network throughput, eMMC
+  load, GPU clock, memory and swap, Wi-Fi RSSI, network throughput, eMMC
   flash wear with JEDEC health translation, and free space on the app partition.
 * **Advanced panels.** HDMI link state per port straight off the receiver
   (resolution, refresh rate, colour depth, pixel clock) and a read-only list of

--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -44,7 +44,7 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **42 
 | `sensor` | `sensor.lg_tv_soc_current` | SoC Current | Processor current draw (`mA`, CPU + Core AVS) |
 | `sensor` | `sensor.lg_tv_cpu_usage` | CPU Usage | Real-time CPU load (`%`) |
 | `sensor` | `sensor.lg_tv_memory_usage` | Memory Usage | System RAM usage (`%`) |
-| `sensor` | `sensor.lg_tv_swap_usage` | Swap Usage | zram Swap usage (`%`) |
+| `sensor` | `sensor.lg_tv_swap_usage` | Swap Usage | Swap usage (`%`), backed by zram or a flash partition depending on the set |
 | `sensor` | `sensor.lg_tv_wifi_signal` | Wi-Fi Signal | Wi-Fi signal strength (`dBm`) |
 | `sensor` | `sensor.lg_tv_download_rate` | Download Rate | Live network throughput (`kB/s`) |
 | `sensor` | `sensor.lg_tv_upload_rate` | Upload Rate | Live network upload throughput (`kB/s`) |

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -820,7 +820,8 @@ async function tick() {
 
     const su = d.swap.total ? 100 * (d.swap.total - d.swap.free) / d.swap.total : 0;
     row('swap', su.toFixed(0) + '<small>%</small>', su,
-        mb(d.swap.total - d.swap.free) + ' / ' + mb(d.swap.total) + ' MB zram', 70);
+        mb(d.swap.total - d.swap.free) + ' / ' + mb(d.swap.total) + ' MB' +
+        (d.swap.backing ? ' ' + d.swap.backing : ''), 70);
 
     // Wired sets report no wlan0; hide rather than showing a blank signal.
     q('row-net').hidden = !(d.wifi || d.net);

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -120,6 +120,11 @@ header{display:flex;justify-content:space-between;align-items:baseline;gap:24px;
 
 .r.hi .lbl{color:var(--w80)}
 .sub{font-size:13px;color:var(--w60);letter-spacing:.02em;margin-top:6px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+/* Network carries the most in its sub - signal, upload rate and two lifetime
+   totals - and the column is capped at 176px. Wrapping keeps the totals
+   readable on a Wi-Fi set, where the dBm prefix would otherwise push them
+   past the ellipsis. */
+#sub-net{white-space:normal}
 
 /* ---- panel block: the second thing worth looking at ---- */
 
@@ -540,6 +545,16 @@ const api = p => p + (K ? (p.includes('?') ? '&' : '?') + 'k=' + encodeURICompon
 const mb = k => (k / 1024).toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 const esc = t => String(t).replace(/[&<>"]/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m]));
 const hrs = h => h == null ? '—' : (h >= 100 ? Math.round(h).toLocaleString() : h.toFixed(1));
+/* Binary steps labelled kB/MB/GB, matching mb() above and the rest of the
+   dashboard. Three significant figures at most: a lifetime byte counter is
+   read for its order of magnitude, not its last digit. */
+const bytes = n => {
+  if (n == null || isNaN(n)) return '—';
+  const u = ['B', 'kB', 'MB', 'GB', 'TB'];
+  let v = n, i = 0;
+  while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+  return (i === 0 || v >= 100 ? Math.round(v) : v.toFixed(1)) + ' ' + u[i];
+};
 
 /* Level is carried by fill and opacity, never by hue - so "hi" is a state
    class that brightens the row rather than turning it red. */
@@ -811,8 +826,14 @@ async function tick() {
     q('row-net').hidden = !(d.wifi || d.net);
     q('row-draw').hidden = !(d.power && d.power.current_ma);
     const rx = d.net ? (d.net.rx / 1024) : 0, tx = d.net ? (d.net.tx / 1024) : 0;
+    /* Totals are per-interface and come from whichever link the rate was
+       measured on, so a Wi-Fi set reads its own counters, not a dormant eth0. */
+    const nt = d.netTotal;
     row('net', rx.toFixed(0) + '<small>kB/s</small>', Math.min(100, rx / 20),
-        (d.wifi ? d.wifi.level + ' dBm  ·  ' : '') + tx.toFixed(0) + ' up', 101);
+        [d.wifi ? d.wifi.level + ' dBm' : null,
+         tx.toFixed(0) + ' up',
+         nt ? bytes(nt.rx) + ' / ' + bytes(nt.tx) : null
+        ].filter(Boolean).join('  ·  '), 101);
 
     const ma = (d.power && d.power.current_ma) || 0;
     row('draw', ma + '<small>mA</small>', Math.min(100, ma / 4),

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -791,7 +791,7 @@ async function tick() {
     q('trange').textContent = noThermal ? 'NO THERMAL SENSOR'
       : hist.length ? ('MIN ' + Math.min(...hist) + '   MAX ' + Math.max(...hist))
       : 'WARMING UP';
-    q('mhz').textContent = d.mhz + ' MHZ';
+    q('mhz').textContent = d.mhz ? d.mhz + ' MHZ' : '';
 
     /* The core figures are positional, so the c0/c1 prefixes were four
        redundant labels competing for a 132px column - at three digits each the

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -224,6 +224,17 @@ function emmcInfo() {
   };
 }
 
+/*
+ * webOS 4.x reports this in kHz (1200000), webOS 9+ in MHz (1200), so a fixed
+ * divisor turns a 1.2 GHz SoC into "1 MHz" on the newer sets. No TV SoC runs
+ * anywhere near 10 GHz, so a value above that can only be the kHz form.
+ */
+function socMhz() {
+  var v = num(rd('/proc/lg/pm/frequency'), 0);
+  if (!v || v < 0) return null;
+  return Math.round(v > 10000 ? v / 1000 : v);
+}
+
 function wifi() {
   var raw = rd('/proc/net/wireless');
   if (!raw) return null;
@@ -231,23 +242,43 @@ function wifi() {
   for (var i = 0; i < lines.length; i++) {
     if (lines[i].indexOf('wlan0') !== -1) {
       var f = lines[i].replace(/\s+/g, ' ').trim().split(' ');
-      return { link: parseFloat(f[2]), level: parseFloat(f[3]) };
+      var link = parseFloat(f[2]), level = parseFloat(f[3]);
+      /*
+       * A wired set still has a wlan0 row, reading zero across the board
+       * because the radio is not associated. Reporting that as 0 dBm states a
+       * measurement that was never taken - the same mistake as 0 C for a
+       * missing thermal sensor.
+       */
+      if (!link && !level) return null;
+      return { link: link, level: level };
     }
   }
   return null;
 }
 
+/*
+ * Whichever interface is actually carrying traffic. This matched wlan0 alone,
+ * so every wired set reported zero throughput forever - the counters it wanted
+ * were on eth0. Loopback is excluded; of the rest the busiest wins, which on a
+ * TV is the one link in use.
+ */
 function netBytes() {
   var raw = rd('/proc/net/dev');
   if (!raw) return null;
-  var lines = raw.split('\n');
+  var lines = raw.split('\n'), best = null;
   for (var i = 0; i < lines.length; i++) {
-    if (lines[i].indexOf('wlan0') !== -1) {
-      var f = lines[i].replace(/\s+/g, ' ').trim().split(' ');
-      return { rx: parseInt(f[1], 10), tx: parseInt(f[9], 10), t: Date.now() };
-    }
+    // Split on the first colon only: the counters follow it, and a long byte
+    // count can run straight up against it with no space.
+    var idx = lines[i].indexOf(':');
+    if (idx === -1) continue;                       // the two header rows
+    var name = lines[i].slice(0, idx).replace(/\s+/g, '');
+    if (!name || name === 'lo') continue;
+    var f = lines[i].slice(idx + 1).replace(/\s+/g, ' ').trim().split(' ');
+    var rx = parseInt(f[0], 10), tx = parseInt(f[8], 10);
+    if (isNaN(rx) || isNaN(tx)) continue;
+    if (!best || rx > best.rx) best = { iface: name, rx: rx, tx: tx, t: Date.now() };
   }
-  return null;
+  return best;
 }
 
 function getVideoSignal() {
@@ -861,7 +892,9 @@ function collectStats(cb) {
 
   var n = netBytes();
   var rate = null;
-  if (n && prevNet && n.t > prevNet.t && n.rx >= prevNet.rx) {
+  // Same interface both samples, or the delta is between two different NICs -
+  // switching from Wi-Fi to ethernet would otherwise report one huge burst.
+  if (n && prevNet && n.iface === prevNet.iface && n.t > prevNet.t && n.rx >= prevNet.rx) {
     var dt = (n.t - prevNet.t) / 1000;
     rate = { rx: Math.round((n.rx - prevNet.rx) / dt), tx: Math.round((n.tx - prevNet.tx) / dt) };
   }
@@ -890,7 +923,7 @@ function collectStats(cb) {
     })(),
     temps: null,   // filled in below from the ring buffer
     load: num(rd('/proc/lg/pm/current_load'), null),
-    mhz: Math.round(num(rd('/proc/lg/pm/frequency'), 0) / 1000),
+    mhz: socMhz(),
     cores: coreMatch ? coreMatch[1].trim().split(/\s+/).map(Number) : [],
     mem: { total: mi.MemTotal || 0, avail: mi.MemAvailable || 0 },
     swap: { total: mi.SwapTotal || 0, free: mi.SwapFree || 0 },
@@ -3064,7 +3097,9 @@ function setupHomeAssistant() {
         payload: {
           name: 'Wi-Fi Signal',
           state_topic: telemetryTopic,
-          value_template: '{{ value_json.wifi.level if value_json.wifi else 0 }}',
+          // none, not 0: a wired set has no signal to report, and 0 dBm would
+          // enter the history as though it had been measured.
+          value_template: '{{ value_json.wifi.level if value_json.wifi else none }}',
           unit_of_measurement: 'dBm',
           device_class: 'signal_strength',
           state_class: 'measurement'

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -931,6 +931,12 @@ function collectStats(cb) {
     loadavg: (rd('/proc/loadavg') || '').split(' ').slice(0, 3),
     wifi: wifi(),
     net: rate,
+    /*
+     * Cumulative counters for the interface the rate came from, so the two
+     * always describe the same link. Kernel counters, so they reset at boot
+     * and start from zero on whichever interface is in use - Wi-Fi or wired.
+     */
+    netTotal: n ? { rx: n.rx, tx: n.tx, iface: n.iface } : null,
     emmc: emmcInfo(),
     signal: getVideoSignal(),
     power: {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -227,12 +227,17 @@ function emmcInfo() {
 /*
  * webOS 4.x reports this in kHz (1200000), webOS 9+ in MHz (1200), so a fixed
  * divisor turns a 1.2 GHz SoC into "1 MHz" on the newer sets. No TV SoC runs
- * anywhere near 10 GHz, so a value above that can only be the kHz form.
+ * anywhere near 10 GHz, so a value above that is taken as the kHz form.
+ *
+ * Only those two conventions have been seen, so the result is bounded rather
+ * than trusted: a set reporting Hz would land far outside a plausible clock,
+ * and nothing is better than a confident wrong figure.
  */
 function socMhz() {
   var v = num(rd('/proc/lg/pm/frequency'), 0);
   if (!v || v < 0) return null;
-  return Math.round(v > 10000 ? v / 1000 : v);
+  var mhz = Math.round(v > 10000 ? v / 1000 : v);
+  return (mhz >= 100 && mhz <= 10000) ? mhz : null;
 }
 
 /*
@@ -280,10 +285,32 @@ function wifi() {
 }
 
 /*
+ * Live first, then busiest. Ranking on byte count alone would keep choosing a
+ * link that has since been unplugged: a set moved from Wi-Fi to ethernet has
+ * a dormant wlan0 holding more lifetime bytes than eth0 will accumulate for
+ * days, and its idle counters would report zero throughput on a busy TV -
+ * which is the fault this replaced, in a new form.
+ *
+ * A kernel too old to publish operstate or carrier leaves every interface
+ * unranked, and the busiest still wins.
+ */
+function ifaceRank(name) {
+  var st = rd('/sys/class/net/' + name + '/operstate');
+  if (st) {
+    st = st.trim();
+    if (st === 'up') return 2;
+    if (st === 'down') return 0;
+    return 1;                                       // "unknown" is not "down"
+  }
+  var car = rd('/sys/class/net/' + name + '/carrier');
+  if (!car) return 1;
+  return car.trim() === '1' ? 2 : 0;
+}
+
+/*
  * Whichever interface is actually carrying traffic. This matched wlan0 alone,
  * so every wired set reported zero throughput forever - the counters it wanted
- * were on eth0. Loopback is excluded; of the rest the busiest wins, which on a
- * TV is the one link in use.
+ * were on eth0. Loopback is excluded.
  */
 function netBytes() {
   var raw = rd('/proc/net/dev');
@@ -299,7 +326,10 @@ function netBytes() {
     var f = lines[i].slice(idx + 1).replace(/\s+/g, ' ').trim().split(' ');
     var rx = parseInt(f[0], 10), tx = parseInt(f[8], 10);
     if (isNaN(rx) || isNaN(tx)) continue;
-    if (!best || rx > best.rx) best = { iface: name, rx: rx, tx: tx, t: Date.now() };
+    var rank = ifaceRank(name);
+    if (!best || rank > best.rank || (rank === best.rank && rx > best.rx)) {
+      best = { iface: name, rank: rank, rx: rx, tx: tx, t: Date.now() };
+    }
   }
   return best;
 }

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -235,6 +235,29 @@ function socMhz() {
   return Math.round(v > 10000 ? v / 1000 : v);
 }
 
+/*
+ * What swap is actually backed by. The B8 swaps to zram, but this is not
+ * universal: a G4 swaps to a flash partition (/dev/f2io-0) and leaves zram0
+ * present with disksize 0. Calling both "zram" understated the cost, since
+ * compressed RAM costs no writes and a partition wears the eMMC.
+ *
+ * The largest device wins, which is the one carrying the pages.
+ */
+function swapBacking() {
+  var raw = rd('/proc/swaps');
+  if (!raw) return null;
+  var lines = raw.split('\n'), best = null, bestSize = -1;
+  for (var i = 1; i < lines.length; i++) {          // row 0 is the header
+    var f = lines[i].replace(/\s+/g, ' ').trim().split(' ');
+    if (f.length < 3 || !f[0]) continue;
+    var size = parseInt(f[2], 10);
+    if (isNaN(size) || size <= bestSize) continue;
+    bestSize = size;
+    best = /zram/i.test(f[0]) ? 'zram' : (f[1] === 'file' ? 'file' : 'flash');
+  }
+  return best;
+}
+
 function wifi() {
   var raw = rd('/proc/net/wireless');
   if (!raw) return null;
@@ -926,7 +949,7 @@ function collectStats(cb) {
     mhz: socMhz(),
     cores: coreMatch ? coreMatch[1].trim().split(/\s+/).map(Number) : [],
     mem: { total: mi.MemTotal || 0, avail: mi.MemAvailable || 0 },
-    swap: { total: mi.SwapTotal || 0, free: mi.SwapFree || 0 },
+    swap: { total: mi.SwapTotal || 0, free: mi.SwapFree || 0, backing: swapBacking() },
     uptime: Math.floor(parseFloat(rd('/proc/uptime') || '0')),
     loadavg: (rd('/proc/loadavg') || '').split(' ').slice(0, 3),
     wifi: wifi(),
@@ -2536,7 +2559,7 @@ var PAGE = [
   '    const swapUsed = swapTotal - swapFree;',
   '    const swapPct = swapTotal ? Math.round((swapUsed / swapTotal) * 100) : 0;',
   '    setProgress("swapbar", swapPct, "var(--purple)");',
-  '    q("swapmeta").textContent = "zram Swap: " + formatMb(swapUsed) + " of " + formatMb(swapTotal) + " (" + swapPct + "%)";',
+  '    q("swapmeta").textContent = "Swap: " + formatMb(swapUsed) + " of " + formatMb(swapTotal) + " (" + swapPct + "%)";',
   '',
   '    // Storage & Network',
   '    q("emmc").textContent = (d.emmc && d.emmc.health) || "unknown";',


### PR DESCRIPTION
Four readings were wrong on an OLED55G42LW (webOS 9+, wired). Three of them stated a number that had never been measured, which is the failure this project has been correcting elsewhere.

**SoC clock.** `/proc/lg/pm/frequency` is kHz on webOS 4.x (`1200000`) and MHz on webOS 9+ (`1200`), so dividing by 1000 unconditionally rendered a 1.2 GHz SoC as `1 MHZ`. A value above 10 GHz is taken as the kHz form. Only those two conventions have been observed, so the result is bounded to a plausible clock rather than trusted - a set reporting Hz lands far outside it and reports nothing instead of a confident wrong figure.

**Network throughput.** `netBytes()` matched `wlan0` alone, so every wired set reported zero forever while its counters sat on `eth0` - on this TV, 12.8 GB against `wlan0`'s zero. Both the dashboard row and the Download/Upload Rate entities were dead. Interfaces that are up are now preferred, then the busiest among them; ranking on bytes alone would keep choosing a link that had since been unplugged, since a dormant `wlan0` outweighs a fresh `eth0` for days. A kernel publishing no operstate or carrier leaves everything unranked and the busiest still wins. A rate is derived only when both samples came from the same interface, so changing link cannot report a burst.

**Wi-Fi signal.** A wired set still has a `wlan0` row in `/proc/net/wireless` reading zero across the board, because the radio is not associated. That was published as `0 dBm`. It now reports nothing, as the GPU clock and panel dimming already do.

**Swap backing.** The dashboard called swap `zram` on every set. A B8 does swap to zram, but this G4 swaps to a flash partition (`/dev/f2io-0`) and leaves `zram0` present with `disksize 0`. The label asserted compressed RAM on a set writing to the eMMC, and the two differ in exactly the way this project cares about: one costs no writes, the other wears the flash. The backing device is read from `/proc/swaps` and reported as `zram`, `flash` or `file`.

**Lifetime data totals** (the one addition). The kernel byte counters were read every poll to derive the rate and then discarded, so the panel could say a link was doing 4 kB/s but never how much had moved through it. The Network row now carries both totals, taken from the same interface the rate was measured on. That sub-line does not fit 176px of `nowrap` once a dBm prefix is present, so that one row wraps rather than ellipsing its totals away.

Verified on the hardware: the clock reads 1200 MHz, throughput tracks `eth0`, Wi-Fi Signal reads unknown in Home Assistant instead of 0, and swap reads `flash`. Interface ranking, swap detection and the clock bound were also checked against fixtures for B8-style zram, a swap file, mixed devices, no swap, a Wi-Fi-only set, a set moved from Wi-Fi to ethernet, a kernel with no link state, and a hypothetical Hz clock.

Everything here degrades to reporting nothing, or to the previous behaviour, when the source it depends on is absent - it has only been run on one set, and the compatibility table spans rather more than that.