### PR TITLE
Stop reporting load for CPU cores that are parked

### DIFF
--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -796,7 +796,11 @@ async function tick() {
     /* The core figures are positional, so the c0/c1 prefixes were four
        redundant labels competing for a 132px column - at three digits each the
        last core was being ellipsised away exactly when the TV was busy. */
-    const cores = (d.cores || []).join('  ·  ');
+    /* Only the cores that are online, so the count moves as the TV parks and
+       wakes them - say how many are down rather than leaving that unexplained. */
+    const live = d.cores || [];
+    const parked = Math.max(0, (d.coresTotal || live.length) - live.length);
+    const cores = live.join('  ·  ') + (parked ? '  ·  ' + parked + ' parked' : '');
     row('cpu', d.load + '<small>%</small>', d.load, cores, 85);
 
     const mu = d.mem.total ? 100 * (d.mem.total - d.mem.avail) / d.mem.total : 0;

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -224,6 +224,39 @@ function emmcInfo() {
   };
 }
 
+/*
+ * Which CPUs are actually running. The TV parks cores under light load, but
+ * /proc/lg/pm/status keeps a slot in its load vector for every core whether
+ * or not it is online - a parked one reads 0, or holds whatever it last
+ * reported before it went down. Observed on a G4: "load: 13 11 11 29" while
+ * only cpu0-2 were online, so that trailing 29 belonged to a core that had
+ * stopped. Publishing those next to live figures invents cores.
+ *
+ * /sys/devices/system/cpu/online is the authoritative list and gives indices
+ * ("0-1", "0,2-3"), which matters because a slot's position is its core
+ * number. cpu_num in the LG file is only a count, so it stands in when sysfs
+ * is unavailable and the cores are assumed to be the lowest indices.
+ */
+function onlineCpus(status) {
+  var raw = rd('/sys/devices/system/cpu/online');
+  if (raw) {
+    var idx = [], parts = raw.trim().split(',');
+    for (var i = 0; i < parts.length; i++) {
+      var range = parts[i].split('-');
+      var lo = parseInt(range[0], 10);
+      var hi = range.length > 1 ? parseInt(range[1], 10) : lo;
+      if (isNaN(lo) || isNaN(hi)) continue;
+      for (var c = lo; c <= hi; c++) idx.push(c);
+    }
+    if (idx.length) return idx;
+  }
+  var m = (status || '').match(/cpu_num:\s*(\d+)/);
+  if (!m) return null;                      // no idea which are live
+  var n = parseInt(m[1], 10), out = [];
+  for (var k = 0; k < n; k++) out.push(k);
+  return out;
+}
+
 function wifi() {
   var raw = rd('/proc/net/wireless');
   if (!raw) return null;
@@ -853,6 +886,16 @@ function collectStats(cb) {
   var mi = meminfo();
   var status = rd('/proc/lg/pm/status') || '';
   var coreMatch = status.match(/load:\s*([\d\s]+)/);
+  var coreSlots = coreMatch ? coreMatch[1].trim().split(/\s+/).map(Number) : [];
+  var liveCpus = onlineCpus(status);
+  var coreLoads = [];
+  if (liveCpus) {
+    for (var ci = 0; ci < liveCpus.length; ci++) {
+      if (liveCpus[ci] < coreSlots.length) coreLoads.push(coreSlots[liveCpus[ci]]);
+    }
+  } else {
+    coreLoads = coreSlots;
+  }
   var cpuAvsMatch = status.match(/cpuavs_current\(mA\):\s*(\d+)/);
   var coreAvsMatch = status.match(/coreavs_current\(mA\):\s*(\d+)/);
   var cpuMa = cpuAvsMatch ? parseInt(cpuAvsMatch[1], 10) : null;
@@ -891,7 +934,10 @@ function collectStats(cb) {
     temps: null,   // filled in below from the ring buffer
     load: num(rd('/proc/lg/pm/current_load'), null),
     mhz: Math.round(num(rd('/proc/lg/pm/frequency'), 0) / 1000),
-    cores: coreMatch ? coreMatch[1].trim().split(/\s+/).map(Number) : [],
+    cores: coreLoads,
+    // Total slots, so the dashboard can say how many are parked rather than
+    // leaving the figure count changing with no explanation.
+    coresTotal: coreSlots.length,
     mem: { total: mi.MemTotal || 0, avail: mi.MemAvailable || 0 },
     swap: { total: mi.SwapTotal || 0, free: mi.SwapFree || 0 },
     uptime: Math.floor(parseFloat(rd('/proc/uptime') || '0')),


### PR DESCRIPTION
The TV takes cores offline under light load, but the `load:` vector in `/proc/lg/pm/status` keeps a slot for every core regardless, and the parser treated all of them as live.

A parked core reads `0`, which presents it as running and idle. Sometimes it is worse than that - it holds whatever it last reported before going down. Sampled on an OLED55G42LW against `/sys/devices/system/cpu/online`:

```
cpu_num | load vector    | online
   2    | 40 53 0 0      | 0-1
   3    | 76 80 67 0     | 0-2
   3    | 13 11 11 29    | 0-2     <- core 3 parked, still reads 29
   2    | 32 15 33 0     | 0-1     <- core 2 parked, still reads 33
```

Only online cores are reported now. They are taken by index from `/sys/devices/system/cpu/online`, since a slot's position is its core number and the online set need not be contiguous. `cpu_num` from the LG file is a count only, so it stands in when sysfs is unavailable; with neither, the vector is reported unchanged rather than guessed at.

The number of figures now varies as cores park and wake, so `coresTotal` is published alongside and the dashboard reports how many are down - `40 · 53 · 2 parked` - rather than leaving the count changing with no explanation.