### PR TITLE
Document the eight missing entities, and check for the next one

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A telemetry server that runs **on** a rooted LG webOS TV. It serves a live
 dashboard to any browser on your network, and bridges the TV into Home
-Assistant over MQTT as a single auto-discovered device with 48 entities.
+Assistant over MQTT as a single auto-discovered device with up to 50 entities.
 
 There are no dependencies. This is ES5 on the Node 0.12 runtime that is on the TV.
 
@@ -22,7 +22,7 @@ though something is playing.
 
 ### Home Assistant (Auto-Discovered Device via MQTT)
 
-All 48 entities arrive over MQTT Discovery as a single device
+The entities arrive over MQTT Discovery as a single device
 <p align="center">
 <img width="1061" height="1042" alt="image" src="https://github.com/user-attachments/assets/1d76b1a2-68d9-42a4-a497-b107d706b235" />
 </p>
@@ -240,7 +240,7 @@ Full detail, including the MQTT ACL guidance and optional TLS, is in
 ## Documentation
 
 * [docs/SECURITY.md](docs/SECURITY.md) &mdash; threat model, SSH migration, MQTT hardening
-* [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) &mdash; all 48 entities, universal media player, example automations
+* [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) &mdash; every entity, universal media player, example automations
 * [docs/IMPLEMENTATION.md](docs/IMPLEMENTATION.md) &mdash; architecture, `/proc/lg` reference, platform quirks
 
 ---

--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -6,7 +6,7 @@ Entity reference and example automations.
 
 ## Entities
 
-Once connected to your MQTT broker, Home Assistant automatically discovers **42 native entities** under a single unified device:
+Once connected to your MQTT broker, Home Assistant discovers these as a single unified device. **50 entities are defined**; any one set publishes fewer, because anything it cannot measure is withheld rather than reported as zero - a non-OLED set gets no panel counters, a set with no ambient sensor gets no room-light reading, and so on. A 2024 G4 on ethernet publishes 46.
 
 | Domain | Entity ID | Name | Description |
 | :--- | :--- | :--- | :--- |
@@ -14,15 +14,19 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **42 
 | `switch` | `switch.lg_tv_mute` | Mute | Toggle audio mute |
 | `switch` | `switch.lg_tv_pixel_refresher_schedule` | Schedule Pixel Refresher | Schedule/cancel 1-hour calibration for next standby |
 | `switch` | `switch.lg_tv_ad_blocker` | Ad & Telemetry Blocker | On-TV `/etc/hosts` blackhole for LG ad/tracking domains |
+| `switch` | `switch.lg_tv_standby_light` | Standby LED | Front standby LED on/off |
+| `switch` | `switch.lg_tv_logo_light` | Logo Light | Logo light on/off, on sets that have one |
 | `number` | `number.lg_tv_volume` | Volume | Volume slider (0–100) |
 | `select` | `select.lg_tv_input_source` | Input Source | HDMI 1–4, Live TV |
 | `select` | `select.lg_tv_app` | Launch App | Installed apps (YouTube, Netflix, Prime Video, Spotify, etc.) |
 | `select` | `select.lg_tv_picture_mode` | Picture Mode | Switch profiles (ISF Dark/Bright, Cinema, Game, Standard) |
 | `select` | `select.lg_tv_sound_output` | Sound Output | Switch outputs (TV Speaker, HDMI ARC, Optical, Headphone) |
+| `select` | `select.lg_tv_sleep_timer` | Sleep Timer | Off, 10, 30, 60, 90 or 120 minutes |
 | `button` | `button.lg_tv_play` | Play | Resume media playback |
 | `button` | `button.lg_tv_pause` | Pause | Pause media playback |
 | `button` | `button.lg_tv_play_pause` | Play / Pause | Toggle media playback |
 | `button` | `button.lg_tv_stop` | Stop | Stop media playback |
+| `button` | `button.lg_tv_screensaver` | Start Screensaver | Starts the screen saver; only available from an app, not an HDMI input or Live TV |
 | `text` | `text.lg_tv_screen_notification` | Screen Notification | Send custom toast messages to TV screen |
 | `button` | `button.lg_tv_restart` | Restart TV | Reboots the TV (requires `allowPower: true`) |
 | `button` | `button.lg_tv_power_off` | Power Off TV | Powers off the TV (requires `allowPower: true`) |
@@ -34,14 +38,17 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **42 
 | `sensor` | `sensor.lg_tv_oled_refresher_status` | Pixel Refresher Status | `Idle` or `Scheduled` |
 | `sensor` | `sensor.lg_tv_oled_screen_shift` | OLED Screen Shift | Pixel orbiting state (`ON` / `OFF`) |
 | `sensor` | `sensor.lg_tv_oled_logo_dimming` | OLED Logo Dimming | Logo luminance reduction (`Low`, `Strong`, `Off`) |
+| `sensor` | `sensor.lg_tv_panel_dimming` | Panel Dimming | ABL / logo dimming activity; withheld on OLED sets and where unmeasured |
 | `sensor` | `sensor.lg_tv_dynamic_range` | Dynamic Range | **Dolby Vision**, **HDR**, or **SDR** |
 | `sensor` | `sensor.lg_tv_picture_mode` | Picture Mode | Current profile (e.g. *Dolby Vision Cinema*) |
 | `sensor` | `sensor.lg_tv_oled_light` | OLED Light | OLED panel backlight level (`0–100%`) |
+| `sensor` | `sensor.lg_tv_ambient_light` | Ambient Light | Room brightness from the ambient sensor (`lux`); withheld on sets without one |
 | `sensor` | `sensor.lg_tv_video_signal` | Video Signal | HDMI resolution & refresh rate (e.g. `3840x2160 @ 60Hz`) |
 | `sensor` | `sensor.lg_tv_audio_output` | Audio Output | Audio scenario (e.g. *Optical / Headphone*, *Internal*) |
 | `sensor` | `sensor.lg_tv_active_app` | Active App | Current foreground app or friendly CEC device |
 | `sensor` | `sensor.lg_tv_soc_temperature` | SoC Temperature | TV processor temperature (`°C`) |
 | `sensor` | `sensor.lg_tv_soc_current` | SoC Current | Processor current draw (`mA`, CPU + Core AVS) |
+| `sensor` | `sensor.lg_tv_gpu_clock` | GPU Clock | GPU PLL output (`MHz`); withheld on sets that do not report it |
 | `sensor` | `sensor.lg_tv_cpu_usage` | CPU Usage | Real-time CPU load (`%`) |
 | `sensor` | `sensor.lg_tv_memory_usage` | Memory Usage | System RAM usage (`%`) |
 | `sensor` | `sensor.lg_tv_swap_usage` | Swap Usage | zram Swap usage (`%`) |
@@ -50,6 +57,7 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **42 
 | `sensor` | `sensor.lg_tv_upload_rate` | Upload Rate | Live network upload throughput (`kB/s`) |
 | `sensor` | `sensor.lg_tv_flash_health` | Flash Storage Health | eMMC remaining health estimate (`>90% (Healthy)`) |
 | `sensor` | `sensor.lg_tv_flash_wear` | Flash Wear Level | JEDEC write-cycle consumption (`0–10%`) |
+| `sensor` | `sensor.lg_tv_app_storage_free` | App Storage Free | Free app storage (`GB`) |
 | `sensor` | `sensor.lg_tv_uptime` | Uptime | TV uptime in seconds |
 | `sensor` | `sensor.lg_tv_tvweb_version` | TVWeb Version | Version of tvweb itself, not the TV firmware (diagnostic) |
 

--- a/scripts/check-entity-docs.py
+++ b/scripts/check-entity-docs.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""
+Check that every discovery entity in tvweb.js appears in the entity table, and
+that the count the docs quote is the number actually defined.
+
+The table drifted for months without anyone noticing: eight entities were
+missing from it, and the README, this table and the code disagreed on how many
+there were - 48, 42 and 50 respectively. A count is easy to leave behind when
+adding an entity, and nothing failed when it was.
+
+Generating the table instead was the obvious alternative and is the wrong one:
+the Entity ID column is what Home Assistant registered at first discovery,
+which depends on the device name and on what the entity was called at the
+time. That cannot be derived from source, and the descriptions are written for
+a reader rather than extracted. So the table stays hand-written and this checks
+it, rather than the other way round.
+
+    ./scripts/check-entity-docs.py
+
+Exits non-zero if an entity is undocumented or a quoted count is wrong.
+"""
+import re, sys, pathlib
+
+root = pathlib.Path(__file__).parent.parent
+src = (root / 'server' / 'tvweb.js').read_text(encoding='utf-8')
+doc_path = root / 'docs' / 'HOME-ASSISTANT.md'
+doc = doc_path.read_text(encoding='utf-8')
+readme = (root / 'README.md').read_text(encoding='utf-8')
+
+# Entity definitions, as publishDiscovery lists them. Keyed by domain and
+# name: an id is not unique (picture_mode is both a sensor and a select), and
+# the id is not what the table lists anyway - see below.
+defined = {}
+for typ, eid, body in re.findall(r"type: '(\w+)', id: '([\w_]+)',(.*?)\n      \}", src, re.S):
+    name = re.search(r"name: '([^']+)'", body)
+    defined[(typ, name.group(1) if name else eid)] = eid
+
+# Documented rows: | `domain` | `domain.device_objectid` | Name | Description |
+#
+# Matched on domain and name rather than entity id. Home Assistant derives the
+# entity id at first discovery from the name it had then, so it need not match
+# the id in the source - cpu_load is registered as sensor.<device>_cpu_usage -
+# and it carries a device prefix that varies with device.id.
+documented = {}
+for domain, entity_id, name in re.findall(r'\|\s*`(\w+)`\s*\|\s*`([\w.]+)`\s*\|\s*([^|]+?)\s*\|', doc):
+    documented[(domain, name)] = entity_id
+
+problems = []
+for key in sorted(defined):
+    if key not in documented:
+        problems.append(f'undocumented: {key[0]}/{defined[key]} ("{key[1]}")')
+for key in sorted(documented):
+    if key not in defined:
+        problems.append(f'documented but not defined: {key[0]} "{key[1]}" ({documented[key]})')
+
+# Any count quoted anywhere has to be the number defined. A set publishes
+# fewer - capability-dependent entities are withheld - so the docs say so in
+# words; what must not drift is the total.
+total = len(defined)
+for label, text in (('README.md', readme), ('docs/HOME-ASSISTANT.md', doc)):
+    for quoted in re.findall(r'(\d+)\s+(?:native\s+)?entities', text):
+        if int(quoted) != total:
+            problems.append(f'{label} says {quoted} entities, {total} are defined')
+
+print(f'{total} entities defined, {len(documented)} rows in the table')
+if problems:
+    print(f'\n{len(problems)} problem(s):')
+    for p in problems:
+        print('  ' + p)
+    sys.exit(1)
+print('every entity is documented and the counts agree')


### PR DESCRIPTION
The entity table had drifted: eight entities were missing from it, and the README, the table and the code each quoted a different total - 48, 42 and 50 respectively. Nothing failed when a count was left behind, so nothing was.

Added the missing rows: standby LED, logo light, sleep timer, screensaver, panel dimming, ambient light, GPU clock and app storage.

The quoted number was wrong in kind as well as in value. A set publishes fewer entities than are defined, because anything it cannot measure is withheld rather than reported as zero - a 2024 G4 on ethernet publishes 46 of the 50. The docs now say that in words and quote only the defined total, which is the part that must not drift.

`scripts/check-entity-docs.py` holds it there: it fails when an entity is defined but undocumented, when a row describes an entity that no longer exists, or when a quoted count disagrees with the code.

Generating the table was the obvious alternative and I think it is the wrong one. The Entity ID column is what Home Assistant registered at first discovery, which depends on the device name and on what the entity was called at the time - `cpu_load` is registered as `sensor.<device>_cpu_usage` - so it cannot be derived from source, and the descriptions are written for a reader rather than extracted. The table stays hand-written and the checker matches on domain and name.

Verified it catches drift: adding a dummy entity fails the check with the undocumented entity and both stale counts.