### PR TITLE
Report whether the screen saver is actually on screen

### DIFF
--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -45,6 +45,7 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **up 
 | `sensor` | `sensor.lg_tv_oled_refresher_cycles` | OLED Refresher Cycles Completed | Lifetime completed JB 2,000-hour deep refresher cycles |
 | `sensor` | `sensor.lg_tv_oled_failure_alerts` | OLED Compensation Failures | Total compensation failure alerts recorded on set |
 | `binary_sensor` | `binary_sensor.lg_tv_oled_asbl_dimmer` | OLED ASBL Protection | State of Auto Static Brightness Limiter / GSR dimmer |
+| `binary_sensor` | `binary_sensor.lg_tv_screen_saver_active` | Screen Saver | Whether a screen saver is on screen now; withheld on sets that do not report it |
 | `sensor` | `sensor.lg_tv_oled_screen_shift` | OLED Screen Shift | Pixel orbiting state (`ON` / `OFF`) |
 | `sensor` | `sensor.lg_tv_oled_logo_dimming` | OLED Logo Dimming | Logo luminance reduction (`Low`, `Strong`, `Off`) |
 

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -1265,6 +1265,7 @@ function collectStats(cb) {
       hasLogo: hasLogoLight === true
     };
     out.gpuMhz = gpuClockMhz();
+    out.screenSaver = screenSaverOn();
   lunaCached('com.palm.connectionmanager/getStatus', {}, 60000, function (cm) {
     // Network name, so the Wi-Fi figures say which network they refer to.
     var w = cm && cm.wifi;
@@ -1449,6 +1450,25 @@ function gpuClockMhz() {
   if (!raw) return null;
   var m = raw.match(/gpu pll out\s*:\s*(\d+)/i);
   return m ? Math.round(parseInt(m[1], 10) / 1000000) : null;
+}
+
+/*
+ * Whether the screen saver is on screen right now. The same file already read
+ * for the GPU clock carries it as "ss: OFF".
+ *
+ * There has been a control to start one since #24 but no way to see whether
+ * it took: turnOnScreenSaver returns true whether or not anything answered the
+ * request, so the only honest confirmation is the set saying so itself.
+ *
+ * A set that does not publish the field reports nothing rather than "off",
+ * which would claim a screen saver is not running on a TV that never says.
+ */
+function screenSaverOn() {
+  var raw = rd('/proc/lg/sys/status');
+  if (!raw) return null;
+  var m = raw.match(/^\s*ss\s*:\s*(\w+)/im);
+  if (!m) return null;
+  return /^(on|1|true)$/i.test(m[1]);
 }
 
 /*
@@ -4002,6 +4022,21 @@ function setupHomeAssistant() {
         }
       },
       {
+        /*
+         * The other half of that button. turnOnScreenSaver reports success
+         * whether or not anything answered the request, so this is the only
+         * confirmation that one is actually on screen. Withheld on sets whose
+         * kernel does not publish it - see publishDiscovery.
+         */
+        type: 'binary_sensor', id: 'screen_saver_active',
+        payload: {
+          name: 'Screen Saver',
+          state_topic: telemetryTopic,
+          value_template: '{{ "ON" if value_json.screenSaver else "OFF" }}',
+          icon: 'mdi:television-shimmer'
+        }
+      },
+      {
         type: 'switch', id: 'ad_blocker',
         payload: {
           name: 'Ad & Telemetry Blocker',
@@ -4235,6 +4270,21 @@ function setupHomeAssistant() {
         } else { keptGpu.push(entities[gi]); }
       }
       entities = keptGpu;
+    }
+
+    /*
+     * Screen saver state, from the same file. A set that never publishes it
+     * would otherwise get an entity reading OFF forever, which asserts that no
+     * screen saver is running on a TV that has never said either way.
+     */
+    if (screenSaverOn() === null) {
+      var keptSs = [];
+      for (var si = 0; si < entities.length; si++) {
+        if (entities[si].id === 'screen_saver_active') {
+          mqttClient.publish(discPfx + '/binary_sensor/' + devId + '/screen_saver_active/config', '', true);
+        } else { keptSs.push(entities[si]); }
+      }
+      entities = keptSs;
     }
 
     /*


### PR DESCRIPTION
There has been a button to start a screen saver since #24, but no way to see whether it worked. `turnOnScreenSaver` reports success whether or not anything answered the request - on an HDMI input or Live TV nothing registers a screen saver at all, which #24 documented - so the only honest confirmation is the set saying so itself.

`/proc/lg/sys/status` carries it as `ss: OFF`, in the file already read every poll for the GPU clock, so this costs no extra syscall.

A set whose kernel does not publish the field has the entity withheld, the same way the GPU clock is, rather than left reading `OFF` forever - that would assert no screen saver is running on a TV that has never said either way.

Parser checked against the real G4 file, a running screen saver, lower-case values, a B8-style file that also carries the GPU PLL line, a file with no `ss` field, and no file at all.

Note this touches the entity table, so it will conflict with #44 if that merges first - trivially, both add rows.