### PR TITLE
Check every entity, not the two thirds the regex happened to match

### DIFF
--- a/scripts/check-entities.py
+++ b/scripts/check-entities.py
@@ -79,9 +79,16 @@ def resolve(path):
     return True
 
 
-blocks = re.findall(
-    r"type: '(switch|number|select|sensor|binary_sensor)', id: '([a-z0-9_]+)',\s*payload: \{(.*?)\n        \}",
-    src, re.S)
+# Every entity, whatever its domain and however its payload is built.
+#
+# Naming the domains meant each new one had to be remembered here, and
+# binary_sensor was not until three of them had shipped. Requiring `payload: {`
+# also skipped any entity whose payload is returned by a function - the Launch
+# App select builds its options that way - so a state-bearing select went
+# unchecked while the run still reported success.
+#
+# The block ends at the closing brace of the entity object, indented six.
+blocks = re.findall(r"type: '(\w+)', id: '([a-z0-9_]+)',(.*?)\n      \}", src, re.S)
 
 failures, checked = [], 0
 print(f'{"entity":30} {"state source":14} paths')
@@ -90,12 +97,19 @@ for typ, eid, body in blocks:
     source = ('telemetry' if 'telemetryTopic' in body
               else 'own topic' if 'Topic' in body else 'none')
     tmpl = re.search(r"value_template:\s*'(.*?)'", body, re.S)
-    paths = sorted(set(re.findall(r'value_json\.([A-Za-z0-9_.]+)', tmpl.group(1)))) if tmpl else []
+    # Read the paths from the whole entity, not just a literal value_template.
+    # Five entities build their template from a helper or across several lines,
+    # and every one of them is state-bearing - mute, input_source, sound_output,
+    # the pixel refresher and the app select - so they were reported as having
+    # no template at all while the run still passed.
+    paths = sorted(set(re.findall(r'value_json\.([A-Za-z0-9_.]+)', body)))
     # A template that guards its own path (`... if value_json.x else none`) is
     # allowed to reference something absent: that is how optional hardware is
-    # handled. Only an unguarded missing path is a real failure.
-    body = tmpl.group(1) if tmpl else ''
-    guarded = 'else none' in body or 'else "' in body
+    # handled. Only an unguarded missing path is a real failure. selectState()
+    # emits `else 'None'` for exactly that reason, so it counts as a guard.
+    text = tmpl.group(1) if tmpl else body
+    guarded = ('else none' in text or 'else "' in text or "else '" in text
+               or 'selectState(' in body)
     missing = [p for p in paths if not resolve(p)]
     bad = [] if guarded else missing
     optional = missing if guarded else []


### PR DESCRIPTION
The checker matched a hard-coded list of domains and required the payload to be an object literal. Both quietly excluded state-bearing entities while the run still reported success - which is the one thing a checker must not do.

- Naming the domains meant every new one had to be remembered here, and `binary_sensor` was not until three of them had shipped in #42.
- Requiring `payload: {` skipped any entity whose payload is returned by a function. The Launch App select builds its options that way, so it went unchecked.
- Reading `value_json` paths only from a literal `value_template` missed five more: mute, input source, sound output, the pixel refresher schedule and that same app select. All state-bearing, all reported as `(no template)`.

Matching on the entity block itself and reading paths from the whole body fixes all three. Against an OLED55G42LW the run goes from 92 paths across 56 entities to **99 across 65**, which is every entity defined.

`selectState()` now counts as a guard: emitting `else 'None'` for a state outside the option list is the entire reason it exists.

Verified it still fails as it should - breaking one path reports `uptime: uptimee` and exits non-zero.