### PR TITLE
Add kB/s unit to upload rate

### DIFF
--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -999,7 +999,7 @@ async function tick() {
     const netParts = [];
     if (d.ssid) netParts.push(esc(d.ssid));
     if (d.wifi && d.wifi.level) netParts.push(d.wifi.level + ' dBm');
-    if (tx > 0) netParts.push(tx.toFixed(0) + ' up');
+    if (tx > 0) netParts.push(tx.toFixed(0) + ' kB/s up');
     if (nt) netParts.push(bytes(nt.rx) + ' / ' + bytes(nt.tx));
     row('net', rx.toFixed(0) + '<small>kB/s</small>', Math.min(100, rx / 20),
         netParts.join('  ·  ') || 'Connected', 101);


### PR DESCRIPTION
The upload throughput in the network sub-line showed "3 up" with no unit. Now shows "3 kB/s up" to match the download rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)