### PR TITLE
Publish the TV's MAC address

### DIFF
--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -344,6 +344,26 @@ function ifaceRank(name) {
 }
 
 /*
+ * The address a magic packet has to be sent to. Waking a set is the one thing
+ * this server cannot do - it is not running when the TV is off - so the README
+ * documents Wake-on-LAN for it and leaves the address for the reader to find
+ * in the TV's menus. The set knows it.
+ *
+ * Read for whichever interface the throughput came from, so a TV on Wi-Fi
+ * reports its Wi-Fi address rather than a wired one with nothing plugged in.
+ * An all-zero address is a placeholder for an interface that has none.
+ */
+function macAddress(iface) {
+  if (!iface) return null;
+  var raw = rd('/sys/class/net/' + iface + '/address');
+  if (!raw) return null;
+  var mac = raw.trim().toLowerCase();
+  if (!/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/.test(mac)) return null;
+  if (mac === '00:00:00:00:00:00') return null;
+  return mac;
+}
+
+/*
  * Whichever interface is actually carrying traffic. This matched wlan0 alone,
  * so every wired set reported zero throughput forever - the counters it wanted
  * were on eth0. Loopback is excluded.
@@ -1253,6 +1273,7 @@ function collectStats(cb) {
      * and start from zero on whichever interface is in use - Wi-Fi or wired.
      */
     netTotal: n ? { rx: n.rx, tx: n.tx, iface: n.iface } : null,
+    mac: n ? macAddress(n.iface) : null,
     emmc: emmcInfo(),
     signal: getVideoSignal(),
     hdmi_diag: hdmiDiag,
@@ -2822,6 +2843,22 @@ function setupHomeAssistant() {
           value_template: '{{ value_json.tvwebVersion }}',
           entity_category: 'diagnostic',
           icon: 'mdi:tag-outline'
+        }
+      },
+      {
+        /*
+         * For the wake_on_lan.send_magic_packet action the Home Assistant
+         * guide sets up, where the address is currently left to the reader.
+         * Diagnostic: it belongs on the device page beside the firmware, and
+         * it is read once rather than watched.
+         */
+        type: 'sensor', id: 'mac_address',
+        payload: {
+          name: 'MAC Address',
+          state_topic: telemetryTopic,
+          value_template: '{{ value_json.mac if value_json.mac else none }}',
+          entity_category: 'diagnostic',
+          icon: 'mdi:ethernet'
         }
       },
       {


### PR DESCRIPTION
Waking a set is the one thing this server cannot do - it is not running when the TV is off - so `docs/HOME-ASSISTANT.md` sets up `wake_on_lan.send_magic_packet` and leaves `mac: "YOUR_TV_MAC_ADDRESS"` for the reader to go and find in the TV's menus. The set knows it, and it is the only part of that documented flow tvweb does not already provide.

Read from `/sys/class/net/<iface>/address` for whichever interface the throughput came from, so a TV on Wi-Fi reports its Wi-Fi address rather than a wired one with nothing plugged into it. Costs no new call - the interface is already chosen each poll for the network counters.

An address that is missing, malformed, or the all-zero placeholder some interfaces carry reports nothing rather than a value that cannot be woken. Case is normalised.

Deliberately not gated at discovery the way the GPU clock and HDMI diagnostics are: a set with no readable network interface is one this server could not have been reached on, so a capability latch would be dead code.

Verified on an OLED55G42LW: `sensor.<device>_mac_address` reads `58:96:0a:42:a2:68` for `eth0`. Parser checked against a real wired and Wi-Fi address, upper case, the all-zero placeholder, malformed text, an empty file, a missing file, and no interface at all. Entity checker passes at 101 paths across 67 entities.