### PR TITLE
fix: prevent standby UI crash and show active panel maintenance indicators

### DIFF
--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -38,9 +38,10 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **up 
 | `sensor` | `sensor.lg_tv_oled_panel_hours` | OLED Panel Hours | Total cumulative operating hours (`h`) |
 | `sensor` | `sensor.lg_tv_oled_hours_since_compensation` | OLED Hours Since Short Cycle | Hours elapsed since last 4h compensation (`h`) |
 | `sensor` | `sensor.lg_tv_oled_hours_until_compensation` | OLED Hours Until Short Cycle | Hours until next short compensation due (`h`) |
+| `sensor` | `sensor.lg_tv_oled_compensation_status` | OLED Compensation Status | `Idle` or `Running` (active panel maintenance) |
 | `sensor` | `sensor.lg_tv_oled_hours_since_refresher` | OLED Hours Since Pixel Refresher | Hours elapsed since last 2,000h deep refresher (`h`) |
 | `sensor` | `sensor.lg_tv_oled_hours_until_refresher` | OLED Hours Until Pixel Refresher | Hours until next 2,000h deep refresher due (`h`) |
-| `sensor` | `sensor.lg_tv_oled_refresher_status` | Pixel Refresher Status | `Idle` or `Scheduled` |
+| `sensor` | `sensor.lg_tv_oled_refresher_status` | Pixel Refresher Status | `Idle`, `Scheduled`, or `Running` (2,000h deep cycle) |
 | `sensor` | `sensor.lg_tv_oled_short_cycles` | OLED Short Cycles Completed | Lifetime completed Off-RS short compensation cycles |
 | `sensor` | `sensor.lg_tv_oled_refresher_cycles` | OLED Refresher Cycles Completed | Lifetime completed JB 2,000-hour deep refresher cycles |
 | `sensor` | `sensor.lg_tv_oled_failure_alerts` | OLED Compensation Failures | Total compensation failure alerts recorded on set |

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -452,7 +452,6 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="cols">
         <div><div class="lbl" id="comp-lbl">Compensation in</div><div class="v num" id="comp">&mdash;</div><div class="sub" id="comp-sub">&mdash;</div></div>
         <div><div class="lbl" id="refr-lbl">Refresher in</div><div class="v num" id="refr">&mdash;</div><div class="sub" id="refr-sub">&mdash;</div></div>
-        <div><div class="lbl">Pixel refresher</div><div class="v" id="rstate">&mdash;</div><div class="sub" id="fail-sub">&mdash;</div></div>
         <div id="lux-cell" hidden><div class="lbl">Room light</div><div class="v num" id="lux">&mdash;</div><div class="sub">Ambient sensor</div></div>
       </div>
 
@@ -1159,27 +1158,27 @@ async function tick() {
       }
     }
     if (o.refresher_status === 'Running') {
-      if (q('refr-lbl')) q('refr-lbl').textContent = 'Refresher';
+      if (q('refr-lbl')) q('refr-lbl').textContent = 'Pixel refresher';
       q('refr').textContent = 'In progress';
       q('refr').style.color = 'var(--cand)';
-      if (q('refr-sub')) q('refr-sub').textContent = 'Completing Deep Calibration (1-hour cycle)';
+      if (q('refr-sub')) q('refr-sub').textContent = 'Running 1-hour calibration';
+    } else if (o.refresher_status === 'Scheduled') {
+      if (q('refr-lbl')) q('refr-lbl').textContent = 'Pixel refresher';
+      q('refr').textContent = 'Scheduled';
+      q('refr').style.color = 'var(--cand)';
+      if (q('refr-sub')) q('refr-sub').textContent = 'Runs on next shutdown';
     } else {
       if (q('refr-lbl')) q('refr-lbl').textContent = 'Refresher in';
       q('refr').textContent = hrs(o.hours_until_refresher) + ' h';
       q('refr').style.color = '';
       if (q('refr-sub')) {
-        q('refr-sub').textContent = (o.refresher_cycles !== undefined && o.refresher_cycles !== null) ?
-          o.refresher_cycles + ' deep cycles completed (JB)' : '2,000-hour calibration';
-      }
-    }
-    q('rstate').textContent = o.refresher_status || '—';
-    if (q('fail-sub')) {
-      if (o.failure_alerts !== undefined && o.failure_alerts !== null) {
-        q('fail-sub').innerHTML = o.failure_alerts === 0 ?
-          '0 failures recorded (Healthy)' :
-          '<span style="color:var(--cand)">' + o.failure_alerts + ' failures recorded</span>';
-      } else {
-        q('fail-sub').textContent = '2,000-hour cycle status';
+        if (o.failure_alerts !== undefined && o.failure_alerts !== null && o.failure_alerts > 0) {
+          q('refr-sub').innerHTML = '<span style="color:var(--cand)">' + o.failure_alerts + ' failures recorded</span>';
+        } else if (o.refresher_cycles !== undefined && o.refresher_cycles !== null) {
+          q('refr-sub').textContent = o.refresher_cycles + ' deep cycles completed (JB)';
+        } else {
+          q('refr-sub').textContent = '2,000-hour calibration';
+        }
       }
     }
 

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -141,6 +141,8 @@ header{display:flex;justify-content:space-between;align-items:flex-start;gap:24p
 .st i{width:7px;height:7px;border-radius:50%;background:var(--w100);flex:none}
 .st.off i{background:transparent;box-shadow:inset 0 0 0 1px var(--w50)}
 .st.off{color:var(--w50)}
+.st.comp i{background:var(--cand);box-shadow:0 0 6px var(--cand)}
+.st.comp{color:var(--cand)}
 
 /* Tiered stream diagnostics */
 .stream-info{margin-top:3px}
@@ -448,9 +450,9 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="lbl">Total power on hours</div>
       <div class="n num" style="margin-top:10px"><span id="ph">&mdash;</span><em>hours</em></div>
       <div class="cols">
-        <div><div class="lbl">Compensation in</div><div class="v num" id="comp">&mdash;</div><div class="sub" id="comp-sub">&mdash;</div></div>
-        <div><div class="lbl">Refresher in</div><div class="v num" id="refr">&mdash;</div><div class="sub" id="refr-sub">&mdash;</div></div>
-        <div><div class="lbl">Refresher state</div><div class="v" id="rstate">&mdash;</div><div class="sub" id="fail-sub">&mdash;</div></div>
+        <div><div class="lbl" id="comp-lbl">Compensation in</div><div class="v num" id="comp">&mdash;</div><div class="sub" id="comp-sub">&mdash;</div></div>
+        <div><div class="lbl" id="refr-lbl">Refresher in</div><div class="v num" id="refr">&mdash;</div><div class="sub" id="refr-sub">&mdash;</div></div>
+        <div><div class="lbl">Pixel refresher state</div><div class="v" id="rstate">&mdash;</div><div class="sub" id="fail-sub">&mdash;</div></div>
         <div id="lux-cell" hidden><div class="lbl">Room light</div><div class="v num" id="lux">&mdash;</div><div class="sub">Ambient sensor</div></div>
       </div>
 
@@ -963,12 +965,19 @@ async function tick() {
     // Panel state first: without it, a blanked screen still reads as though
     // something were being displayed.
     const ps = d.powerState || {};
+    const o = d.oled || {};
+    const isComp = !!(o.comp_status === 'Running' || (ps.raw === 'Active Standby' && o.hours_until_comp === 0));
     const stEl = q('state');
-    stEl.querySelector('span').textContent = ps.label || '—';
-    stEl.classList.toggle('off', ps.screenOn === false);
-    q('source').parentElement.classList.toggle('dim', ps.screenOn === false);
-
-    q('source').textContent = d.display_title || d.app_name || d.app || '—';
+    stEl.classList.toggle('comp', isComp);
+    stEl.classList.toggle('off', !isComp && ps.screenOn === false);
+    if (isComp) {
+      stEl.querySelector('span').textContent = 'Active Standby';
+      q('source').textContent = 'Completing Panel Maintenance (Short Cycle)';
+    } else {
+      stEl.querySelector('span').textContent = ps.label || '—';
+      q('source').textContent = d.display_title || d.app_name || d.app || '—';
+    }
+    q('source').parentElement.classList.toggle('dim', ps.screenOn === false && !isComp);
     const pic = d.picture || {};
 
     // Summarise the collapsed groups so their current values are readable
@@ -1134,17 +1143,34 @@ async function tick() {
     const hasOled = !!(d.oled && d.oled.panel_hours !== undefined) &&
                     !(d.capabilities && d.capabilities.oled === false);
     q('panelblock').hidden = !hasOled;
-    const o = d.oled || {};
     q('ph').textContent = (o.panel_hours || 0).toLocaleString();
-    q('comp').textContent = hrs(o.hours_until_comp) + ' h';
-    if (q('comp-sub')) {
-      q('comp-sub').textContent = (o.comp_cycles !== undefined && o.comp_cycles !== null) ?
-        o.comp_cycles + ' cycles completed (Off-RS)' : '4-hour short cycle';
+    if (isComp) {
+      if (q('comp-lbl')) q('comp-lbl').textContent = 'Compensation';
+      q('comp').textContent = 'In progress';
+      q('comp').style.color = 'var(--cand)';
+      if (q('comp-sub')) q('comp-sub').textContent = 'Completing Panel Maintenance (Short Cycle)';
+    } else {
+      if (q('comp-lbl')) q('comp-lbl').textContent = 'Compensation in';
+      q('comp').textContent = hrs(o.hours_until_comp) + ' h';
+      q('comp').style.color = '';
+      if (q('comp-sub')) {
+        q('comp-sub').textContent = (o.comp_cycles !== undefined && o.comp_cycles !== null) ?
+          o.comp_cycles + ' cycles completed (Off-RS)' : '4-hour short cycle';
+      }
     }
-    q('refr').textContent = hrs(o.hours_until_refresher) + ' h';
-    if (q('refr-sub')) {
-      q('refr-sub').textContent = (o.refresher_cycles !== undefined && o.refresher_cycles !== null) ?
-        o.refresher_cycles + ' deep cycles completed (JB)' : '2,000-hour calibration';
+    if (o.refresher_status === 'Running') {
+      if (q('refr-lbl')) q('refr-lbl').textContent = 'Refresher';
+      q('refr').textContent = 'In progress';
+      q('refr').style.color = 'var(--cand)';
+      if (q('refr-sub')) q('refr-sub').textContent = 'Completing Deep Calibration (1-hour cycle)';
+    } else {
+      if (q('refr-lbl')) q('refr-lbl').textContent = 'Refresher in';
+      q('refr').textContent = hrs(o.hours_until_refresher) + ' h';
+      q('refr').style.color = '';
+      if (q('refr-sub')) {
+        q('refr-sub').textContent = (o.refresher_cycles !== undefined && o.refresher_cycles !== null) ?
+          o.refresher_cycles + ' deep cycles completed (JB)' : '2,000-hour calibration';
+      }
     }
     q('rstate').textContent = o.refresher_status || '—';
     if (q('fail-sub')) {
@@ -1153,7 +1179,7 @@ async function tick() {
           '0 failures recorded (Healthy)' :
           '<span style="color:var(--cand)">' + o.failure_alerts + ' failures recorded</span>';
       } else {
-        q('fail-sub').textContent = 'Calibration status';
+        q('fail-sub').textContent = '2,000-hour cycle status';
       }
     }
 
@@ -1259,6 +1285,12 @@ async function tick() {
       for (let b of inBtns) {
         b.classList.toggle('on', b.id === 'in_' + d.app);
       }
+    } else {
+      if (q('currapp-lbl')) q('currapp-lbl').textContent = isComp ? 'MAINTENANCE' : (ps.label ? ps.label.toUpperCase() : 'STANDBY');
+      const inBtns = q('inputs') ? q('inputs').querySelectorAll('button') : [];
+      for (let b of inBtns) {
+        b.classList.toggle('on', false);
+      }
     }
 
     if (d.apps && d.apps.length) {
@@ -1268,7 +1300,7 @@ async function tick() {
       } else {
         const appBtns = q('apps') ? q('apps').querySelectorAll('button') : [];
         for (let b of appBtns) {
-          b.classList.toggle('on', b.id === 'app_' + d.app.replace(/[^a-zA-Z0-9_-]/g, '_') || b.id === 'app_com_webos_app_' + d.app);
+          b.classList.toggle('on', !!(d.app && (b.id === 'app_' + d.app.replace(/[^a-zA-Z0-9_-]/g, '_') || b.id === 'app_com_webos_app_' + d.app)));
         }
       }
     }

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -452,7 +452,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="cols">
         <div><div class="lbl" id="comp-lbl">Compensation in</div><div class="v num" id="comp">&mdash;</div><div class="sub" id="comp-sub">&mdash;</div></div>
         <div><div class="lbl" id="refr-lbl">Refresher in</div><div class="v num" id="refr">&mdash;</div><div class="sub" id="refr-sub">&mdash;</div></div>
-        <div><div class="lbl">Pixel refresher state</div><div class="v" id="rstate">&mdash;</div><div class="sub" id="fail-sub">&mdash;</div></div>
+        <div><div class="lbl">Pixel refresher</div><div class="v" id="rstate">&mdash;</div><div class="sub" id="fail-sub">&mdash;</div></div>
         <div id="lux-cell" hidden><div class="lbl">Room light</div><div class="v num" id="lux">&mdash;</div><div class="sub">Ambient sensor</div></div>
       </div>
 

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -450,8 +450,8 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="lbl">Total power on hours</div>
       <div class="n num" style="margin-top:10px"><span id="ph">&mdash;</span><em>hours</em></div>
       <div class="cols">
-        <div><div class="lbl" id="comp-lbl">Compensation in</div><div class="v num" id="comp">&mdash;</div><div class="sub" id="comp-sub">&mdash;</div></div>
-        <div><div class="lbl" id="refr-lbl">Refresher in</div><div class="v num" id="refr">&mdash;</div><div class="sub" id="refr-sub">&mdash;</div></div>
+        <div><div class="lbl" id="comp-lbl">Panel maintenance in</div><div class="v num" id="comp">&mdash;</div><div class="sub" id="comp-sub">&mdash;</div></div>
+        <div><div class="lbl" id="refr-lbl">Pixel refresher in</div><div class="v num" id="refr">&mdash;</div><div class="sub" id="refr-sub">&mdash;</div></div>
         <div id="lux-cell" hidden><div class="lbl">Room light</div><div class="v num" id="lux">&mdash;</div><div class="sub">Ambient sensor</div></div>
       </div>
 
@@ -1144,12 +1144,12 @@ async function tick() {
     q('panelblock').hidden = !hasOled;
     q('ph').textContent = (o.panel_hours || 0).toLocaleString();
     if (isComp) {
-      if (q('comp-lbl')) q('comp-lbl').textContent = 'Compensation';
+      if (q('comp-lbl')) q('comp-lbl').textContent = 'Panel maintenance';
       q('comp').textContent = 'In progress';
       q('comp').style.color = 'var(--cand)';
       if (q('comp-sub')) q('comp-sub').textContent = 'Completing Panel Maintenance (Short Cycle)';
     } else {
-      if (q('comp-lbl')) q('comp-lbl').textContent = 'Compensation in';
+      if (q('comp-lbl')) q('comp-lbl').textContent = 'Panel maintenance in';
       q('comp').textContent = hrs(o.hours_until_comp) + ' h';
       q('comp').style.color = '';
       if (q('comp-sub')) {
@@ -1168,7 +1168,7 @@ async function tick() {
       q('refr').style.color = 'var(--cand)';
       if (q('refr-sub')) q('refr-sub').textContent = 'Runs on next shutdown';
     } else {
-      if (q('refr-lbl')) q('refr-lbl').textContent = 'Refresher in';
+      if (q('refr-lbl')) q('refr-lbl').textContent = 'Pixel refresher in';
       q('refr').textContent = hrs(o.hours_until_refresher) + ' h';
       q('refr').style.color = '';
       if (q('refr-sub')) {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -27,7 +27,7 @@ var zlib = require('zlib');
  * a link to /releases/tag/v<version>, so a value with no tag behind it gives a
  * 404 rather than a wrong page.
  */
-var TVWEB_VERSION = '0.17.0';
+var TVWEB_VERSION = '0.18.0';
 
 // ---------------------------------------------------------------- config
 var CONFIG = {
@@ -1032,13 +1032,20 @@ function detectOled(cb) {
     });
 }
 
-function refreshOledStats(picSettings, cb) {
+function refreshOledStats(picSettings, pState, cb) {
   var now = Date.now();
   if (cachedOled && (now - lastOledCheck < 30000)) {
     if (picSettings) {
       if (picSettings.screenShift) cachedOled.screen_shift = picSettings.screenShift;
       if (picSettings.logoLuminanceAdjust) cachedOled.logo_dimming = picSettings.logoLuminanceAdjust;
     }
+    var pnStateCached = rd('/mnt/lg/cmn_data/pnwash/state');
+    var jobScopeCached = rd('/mnt/lg/cmn_data/pnwash/jobScope');
+    var isPnwashRunningCached = (pnStateCached && pnStateCached.indexOf('2') === 0) || (jobScopeCached === '1');
+    var isCompRunningCached = isPnwashRunningCached ||
+      (pState && pState.raw === 'Active Standby' && cachedOled.hours_until_comp === 0);
+    cachedOled.comp_status = isCompRunningCached ? 'Running' : 'Idle';
+    cachedOled.comp_status_label = isCompRunningCached ? 'Completing Panel Maintenance (Short Cycle)' : 'Idle';
     return cb(cachedOled);
   }
 
@@ -1134,6 +1141,14 @@ function refreshOledStats(picSettings, cb) {
     var asblStatus = hasTpcMonitoring ? ((tpcOffExists || socTpcRaw === '0') ? 'Disabled' : 'Active') : null;
     var gsrStatus = hasTpcMonitoring ? (gsrOffExists ? 'Disabled' : 'Active') : null;
 
+    var pnStateRaw = rd('/mnt/lg/cmn_data/pnwash/state');
+    var jobScopeRaw = rd('/mnt/lg/cmn_data/pnwash/jobScope');
+    var isPnwashRunning = (pnStateRaw && pnStateRaw.indexOf('2') === 0) || (jobScopeRaw === '1');
+    var isCompRunning = isPnwashRunning ||
+      (pState && pState.raw === 'Active Standby' && hoursUntilComp === 0);
+    var compStatus = isCompRunning ? 'Running' : 'Idle';
+    var compStatusLabel = isCompRunning ? 'Completing Panel Maintenance (Short Cycle)' : 'Idle';
+
     cachedOled = {
       panel_hours: panelHours,
       panel_hours_exact: panelHoursExact,
@@ -1143,6 +1158,8 @@ function refreshOledStats(picSettings, cb) {
       comp_interval_hours: compInterval,
       comp_interval_units: compIntervalUnits,
       comp_cycles: offRsCycles,
+      comp_status: compStatus,
+      comp_status_label: compStatusLabel,
       refresher_interval_hours: REFRESHER_INTERVAL_HOURS,
       last_refresher_hours: lastRefresher,
       hours_since_refresher: hoursSinceRefresher,
@@ -1448,7 +1465,7 @@ function collectStats(cb) {
                     out.oled = null;
                     return flushStats(out);
                   }
-                  refreshOledStats((pic && pic.settings) ? pic.settings : null, function (oled) {
+                  refreshOledStats((pic && pic.settings) ? pic.settings : null, out.powerState, function (oled) {
                     out.oled = oled;
                     flushStats(out);
                   });
@@ -3116,6 +3133,15 @@ function setupHomeAssistant() {
         }
       },
       {
+        type: 'sensor', id: 'oled_compensation_status',
+        payload: {
+          name: 'OLED Compensation Status',
+          state_topic: telemetryTopic,
+          value_template: '{{ value_json.oled.comp_status if value_json.oled else "Unknown" }}',
+          icon: 'mdi:autorenew'
+        }
+      },
+      {
         type: 'sensor', id: 'oled_refresher_status',
         payload: {
           name: 'Pixel Refresher Status',
@@ -3432,7 +3458,8 @@ function setupHomeAssistant() {
 
     var OLED_ONLY = {
       oled_panel_hours: 1, oled_hours_since_compensation: 1,
-      oled_hours_until_compensation: 1, oled_hours_since_refresher: 1,
+      oled_hours_until_compensation: 1, oled_compensation_status: 1,
+      oled_hours_since_refresher: 1,
       oled_hours_until_refresher: 1, oled_refresher_status: 1,
       oled_short_cycles: 1, oled_refresher_cycles: 1,
       oled_failure_alerts: 1, oled_asbl_dimmer: 1,


### PR DESCRIPTION
## Summary

This PR addresses standby handling and provides clean, human-readable indicators when LG webOS OLED TVs enter standby during panel maintenance:

1. **Fix Standby UI Crash (`.stale` Dimming)**:
   - When in standby, `d.app` is `undefined`. In `server/assets/ui.html`, iterating over app buttons called `d.app.replace(...)`, throwing an unhandled `TypeError`.
   - The uncaught error caused the poll tick to fail and applied `.stale` (`opacity: 0.35`) permanently to `document.body`.
   - Added null-guards for `d.app` and reset active inputs / set current app label to `STANDBY` (or `MAINTENANCE`).

2. **Human-Readable 2-Column OLED Panel Maintenance Layout**:
   - Dropped the redundant third 'Pixel refresher' column that permanently showed 'Idle' for 2,000 hours.
   - Updated labels to clear, human-readable phrasing:
     - **Card 1 (Short Cycle)**: **`Panel maintenance in`** · `4.0 h` · `4-hour short cycle` (or `In progress` · `Completing Panel Maintenance (Short Cycle)`).
     - **Card 2 (Deep Cycle)**: **`Pixel refresher in`** · `582 h` · `2,000-hour calibration` (or `Scheduled` / `In progress`).
   - Balanced 2-column symmetry with zero text wrapping.

3. **Active Short Cycle Detection & Telemetry**:
   - Evaluates `/mnt/lg/cmn_data/pnwash/state`, `jobScope`, and power states to detect when an Off-RS short cycle is actively running.
   - Exposes `comp_status: 'Running' | 'Idle'` and `comp_status_label: 'Completing Panel Maintenance (Short Cycle)' | 'Idle'`.
   - Updates the web dashboard header power badge with amber `.st.comp` styling and sub-header `Completing Panel Maintenance (Short Cycle)` when running.

4. **Home Assistant MQTT Discovery**:
   - Added sensor entity `oled_compensation_status` (`OLED Compensation Status`) to Home Assistant MQTT discovery.
   - Documented in `docs/HOME-ASSISTANT.md`.

5. **Version Bump**:
   - Bumped `TVWEB_VERSION` to `0.18.0`.