### PR TITLE
MQTT settings in the dashboard, and a setup flow that does not assume MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ network. Enable it deliberately.
 Recommended: Give the TV its own MQTT user with a
 restricted ACL, rather than reusing your main Home Assistant credentials. See [docs/SECURITY.md](docs/SECURITY.md)
 
+Once the server is running, the broker settings, topic prefix and device identity
+can also be changed from the dashboard under **MQTT settings**, without editing
+the file or reaching for SSH. Saving writes `config.json` on the TV and restarts
+the server to apply it. Everything that decides who can reach the server at all
+&mdash; `port`, `host`, `allowControl`, `allowPower`, `token` &mdash; stays
+file-only.
+
 ### Multiple TVs
 
 Each TV on the same broker needs a unique `topicPrefix` and `device.id`,

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # LG webOS TV Dashboard & Home Assistant Bridge
 
-A telemetry server that runs **on** a rooted LG webOS TV. It serves a live
-dashboard to any browser on the network, and will optionally bridge the TV into
-Home Assistant over MQTT as a single auto-discovered device with up to 61
-entities.
+A server that runs **on** a rooted LG webOS TV. It serves a live dashboard to
+any browser on the network, and will optionally bridge the TV into Home
+Assistant over MQTT as a single auto-discovered device with up to 61 entities.
 
 The dashboard needs nothing but the TV. Home Assistant and MQTT are an optional
 second half &mdash; [step 3](#3-home-assistant--mqtt-optional) explains what

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Assistant over MQTT as a single auto-discovered device with up to 61 entities.
 
 The dashboard needs nothing but the TV. Home Assistant and MQTT are an optional
 second half &mdash; [step 3](#3-home-assistant--mqtt-optional) explains what
-they are and how to decide whether to bother.
+they are.
 
 There are no dependencies. This is ES5 on the Node 0.12 runtime that is on the TV.
 
@@ -68,8 +68,7 @@ bind-mounting over `/etc/hosts` that persists across reboots.
    entities arrive as a single auto-discovered device &mdash; no YAML, no LG
    account &mdash; so the TV can be automated and its telemetry recorded
    alongside everything else in the house.
-   [Step 3](#3-home-assistant--mqtt-optional) explains what MQTT is and how to
-   decide whether it is wanted.
+   [Step 3](#3-home-assistant--mqtt-optional) explains what MQTT is.
 
 ## Core features
 
@@ -201,15 +200,6 @@ This project publishes the TV's telemetry to a broker, and describes its own
 entities using the **MQTT Discovery** convention. Home Assistant reads that
 description and creates the device with all its sensors and controls by itself.
 There is no YAML to write.
-
-### Deciding whether to bother
-
-Worth it for: driving the TV from automations, recording panel hours or
-temperature over months, alerting on Pixel Refresher, putting the TV on the same
-dashboard as everything else in the house.
-
-Not worth it for: watching live numbers and pressing buttons. That is the
-dashboard, and it is already installed.
 
 The bridge needs a broker reachable on the network. Home Assistant is the usual
 reason to run one, but not a requirement &mdash; see

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ bind-mounting over `/etc/hosts` that persists across reboots.
    engine is actually running and sampling your screen, your advertising identifier,
    data agreements, and an on-TV `/etc/hosts` blackhole for LG ad and telemetry domains.
 
+5. **Integrating the TV into Home Assistant.** Optional, over MQTT: up to 61
+   entities arrive as a single auto-discovered device &mdash; no YAML, no LG
+   account &mdash; so the TV can be automated and its telemetry recorded
+   alongside everything else in the house.
+   [Step 3](#3-home-assistant--mqtt-optional) explains what MQTT is and how to
+   decide whether it is wanted.
+
 ## Core features
 
 * **OLED panel health.** Panel hours, compensation and Pixel Refresher countdowns

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ own after a few seconds.
 Nothing else is needed. Home Assistant picks up the device within a few seconds
 of the bridge connecting.
 
+The panel reports whether the bridge is connected to the broker and how long ago
+it last published, so a wrong address or a rejected password shows up there
+rather than in the log on the TV.
+
 ### Setting it up from a config file
 
 Equivalent to the above, and the better route for installing several TVs from

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # LG webOS TV Dashboard & Home Assistant Bridge
 
 A telemetry server that runs **on** a rooted LG webOS TV. It serves a live
-dashboard to any browser on your network, and bridges the TV into Home
-Assistant over MQTT as a single auto-discovered device with up to 61 entities.
+dashboard to any browser on the network, and will optionally bridge the TV into
+Home Assistant over MQTT as a single auto-discovered device with up to 61
+entities.
+
+The dashboard needs nothing but the TV. Home Assistant and MQTT are an optional
+second half &mdash; [step 3](#3-home-assistant--mqtt-optional) explains what
+they are and how to decide whether to bother.
 
 There are no dependencies. This is ES5 on the Node 0.12 runtime that is on the TV.
 
@@ -101,8 +106,9 @@ bind-mounting over `/etc/hosts` that persists across reboots.
 
 * A rooted LG webOS TV ([Root tool here](https://github.com/throwaway96/dejavuln-autoroot/)) with the
   [Homebrew Channel](https://github.com/webosbrew/webos-homebrew-channel).
-* An MQTT broker reachable on your LAN, if you want the Home Assistant side.
-  The dashboard works without one.
+* Nothing else for the dashboard.
+* An MQTT broker on the network, and usually Home Assistant, only if the
+  bridge in [step 3](#3-home-assistant--mqtt-optional) is wanted.
 
 ### Tested on
 
@@ -145,68 +151,150 @@ root with no password. That comes from the rooting rather than from this
 project, but it is the largest exposure on the TV and worth closing when you
 get the chance.
 
-## 2. Configure
-
-```bash
-cp config.example.json server/config.json
-```
-
-Set your broker under `mqtt` and turn it on. Leaving `device.name` and
-`device.model` empty makes the TV report its own model and firmware at runtime.
-Panel hours, Pixel Refresher and Screen Shift appear on OLED sets only; add
-`"panel": "lcd"` or `"panel": "oled"` if a set is read the wrong way.
-
-Both halves are independent, so run whichever you want:
-
-| | `web.enabled` | `mqtt.enabled` |
-| :--- | :--- | :--- |
-| Dashboard and Home Assistant *(default)* | `true` | `true` |
-| Dashboard only | `true` | `false` |
-| Home Assistant only | `false` | `true` |
-
-If you drive everything from Home Assistant, set `"web": { "enabled": false }`.
-The dashboard is an unauthenticated control endpoint unless you set `token`, so
-an MQTT-only install is better off without one. With both disabled the server
-exits rather than idling.
-
-`allowPower` ships disabled, because there is no authentication unless you set
-`token` &mdash; a fresh install should not expose "turn the TV off" to the whole
-network. Enable it deliberately.
-
-Recommended: Give the TV its own MQTT user with a
-restricted ACL, rather than reusing your main Home Assistant credentials. See [docs/SECURITY.md](docs/SECURITY.md)
-
-Once the server is running, the broker settings, topic prefix and device identity
-can also be changed from the dashboard under **MQTT settings**, without editing
-the file or reaching for SSH. Saving writes `config.json` on the TV and restarts
-the server to apply it. Everything that decides who can reach the server at all
-&mdash; `port`, `host`, `allowControl`, `allowPower`, `token` &mdash; stays
-file-only.
-
-### Multiple TVs
-
-Each TV on the same broker needs a unique `topicPrefix` and `device.id`,
-otherwise they overwrite each other's state and disconnect each other.
-`deploy.sh` checks for `server/config.<tv-ip>.json` before falling back to
-`server/config.json`.
-
-## 3. Install
+## 2. Install the dashboard
 
 ```bash
 cd server
 ./deploy.sh <tv-ip> --persist
 ```
 
+Then open **`http://<tv-ip>:8080/`**.
+
+No configuration is needed for this part. Without a config file the dashboard
+runs on port 8080, the controls are live, MQTT is off, and power off / reboot
+are disabled. Nothing is sent anywhere: the server talks to the TV and to
+whoever opens the page.
+
 `--persist` installs a boot hook so it survives reboots. The script copies over
 SSH where available, falling back to telnet; `--telnet` forces the old path. The
 telnet path has to find this machine's LAN address to serve the files from; if
 it cannot, pass it as `MYIP=192.168.x.y ./deploy.sh <tv-ip>`.
 
-Then open **`http://<tv-ip>:8080/`**.
+Panel hours, Pixel Refresher and Screen Shift are read on OLED sets only. If a
+set is detected the wrong way, add `"panel": "lcd"` or `"panel": "oled"` to
+`config.json`.
 
-If you configured MQTT, Home Assistant discovers the device automatically &mdash;
-no YAML. See [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) for the entity
-list and example automations.
+That is a complete install. Everything below is optional.
+
+## 3. Home Assistant & MQTT (optional)
+
+### What these are
+
+**Home Assistant** is open-source home automation software that runs on the
+user's own hardware &mdash; a Raspberry Pi, a NUC, a container on a NAS. It
+gathers devices from different vendors into one place and automates them. It is
+not a service, and nothing here talks to a company's cloud.
+
+**MQTT** is a lightweight messaging protocol. Something publishes a message to a
+named topic, and anything subscribed to that topic receives it. It needs a
+**broker** &mdash; a small server that relays those messages between publishers
+and subscribers. [Mosquitto](https://mosquitto.org/) is the usual one, and Home
+Assistant ships it as a one-click add-on.
+
+This project publishes the TV's telemetry to a broker, and describes its own
+entities using the **MQTT Discovery** convention. Home Assistant reads that
+description and creates the device with all its sensors and controls by itself.
+There is no YAML to write.
+
+### Deciding whether to bother
+
+Worth it for: driving the TV from automations, recording panel hours or
+temperature over months, alerting on Pixel Refresher, putting the TV on the same
+dashboard as everything else in the house.
+
+Not worth it for: watching live numbers and pressing buttons. That is the
+dashboard, and it is already installed.
+
+The bridge needs a broker reachable on the network. Home Assistant is the usual
+reason to run one, but not a requirement &mdash; see
+[Using MQTT without Home Assistant](#using-mqtt-without-home-assistant).
+
+### Setting it up from the dashboard
+
+Open the dashboard, then **MQTT settings** in the controls column. Fill in the
+broker address and credentials, switch **MQTT bridge** on, and save. The server
+writes `config.json` on the TV and restarts itself; the page reconnects on its
+own after a few seconds.
+
+Nothing else is needed. Home Assistant picks up the device within a few seconds
+of the bridge connecting.
+
+### Setting it up from a config file
+
+Equivalent to the above, and the better route for installing several TVs from
+one machine or for keeping the settings under version control.
+
+```bash
+cp config.example.json server/config.json
+```
+
+Set the broker under `mqtt` and set `enabled` to `true`, then run `deploy.sh`
+again. Leaving `device.name` and `device.model` empty makes the TV report its
+own model and firmware at runtime.
+
+`deploy.sh` only installs this file if the TV does not already have one, so it
+will not overwrite settings saved from the dashboard. To replace an existing
+config, edit it through the dashboard or remove `/var/lib/tvweb/config.json`
+first.
+
+### Which settings live where
+
+The dashboard can change the broker, credentials, topic prefix and device
+identity &mdash; the things that decide *where* telemetry goes.
+
+`port`, `host`, `allowControl`, `allowPower` and `token` are file-only. They
+decide *who can reach the server at all*, and a web UI able to widen its own
+exposure would defeat the point of setting them. Edit those in `config.json`
+and redeploy, or edit `/var/lib/tvweb/config.json` on the TV and restart.
+
+`allowPower` ships disabled, because there is no authentication unless `token`
+is set &mdash; a fresh install should not expose "turn the TV off" to the whole
+network. Enable it deliberately.
+
+Recommended: give the TV its own MQTT user with a restricted ACL rather than
+reusing the main Home Assistant credentials. See
+[docs/SECURITY.md](docs/SECURITY.md).
+
+### Using MQTT without Home Assistant
+
+The bridge is a plain MQTT publisher, so anything that speaks MQTT can read it.
+Telemetry is published as JSON to `<topicPrefix>/telemetry`, availability to
+`<topicPrefix>/status`, and commands are accepted on `<topicPrefix>/command/*`.
+
+```bash
+mosquitto_sub -h <broker> -t 'lgtv/#' -v
+```
+
+Node-RED, Telegraf into InfluxDB, or a script subscribing to that topic all work
+the same way. The Discovery messages are simply ignored by anything that is not
+Home Assistant.
+
+### Multiple TVs
+
+Each TV on the same broker needs a unique `topicPrefix` and `device.id`,
+otherwise they overwrite each other's state and disconnect each other. Both are
+editable from each TV's own dashboard.
+
+For the config-file route, `deploy.sh` checks for `server/config.<tv-ip>.json`
+before falling back to `server/config.json`, which keeps per-TV settings from
+being flattened by a shared file.
+
+### Running one half without the other
+
+| | `web.enabled` | `mqtt.enabled` |
+| :--- | :--- | :--- |
+| Dashboard and Home Assistant | `true` | `true` |
+| Dashboard only *(default)* | `true` | `false` |
+| Home Assistant only | `false` | `true` |
+
+With the dashboard disabled the server is an MQTT bridge with no web interface,
+which is the safer shape if everything is driven from Home Assistant &mdash; the
+dashboard is an unauthenticated control endpoint unless `token` is set. Note
+that this also removes the settings UI, so an MQTT-only install is configured by
+file. With both disabled the server exits rather than idling.
+
+See [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) for the entity list and
+example automations.
 
 ## Managing it
 
@@ -234,6 +322,13 @@ anyone who can reach the port can use every enabled control. On a home LAN that
 is usually the point but you can set `"token": "something-long"` in
 `config.json` if you want it gated, and never port-forward it. If you only use
 Home Assistant, `"web": { "enabled": false }` removes the endpoint entirely.
+
+The MQTT settings panel is part of that surface: on a default install, anyone
+who can reach the port can change the broker the TV publishes to, and so
+redirect its telemetry. It is gated by `token` and by `allowControl` like the
+rest of the controls, and it cannot change `port`, `host`, `allowControl`,
+`allowPower` or `token` themselves &mdash; those stay file-only so the UI cannot
+widen its own exposure. The stored broker password is never sent to the browser.
 
 Setting a token affects the dashboard only. **Home Assistant is unaffected**,
 since MQTT is a separate channel.

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -695,7 +695,7 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="btns"><button id="privtoggle" onclick="togglePrivacy()">Show privacy panel</button></div>
     </div>
 
-    <div class="set"><div class="lbl">Home Assistant</div>
+    <div class="set"><div class="lbl">Home Assistant Integration</div>
       <div class="btns"><button id="mqtttoggle" onclick="toggleMqtt()">MQTT settings</button></div>
     </div>
 

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -323,6 +323,26 @@ button[disabled]:hover{color:var(--w60);border-color:var(--w12)}
 .pv-d>summary .cur{margin-left:auto;font-family:'Manrope';font-weight:500;font-size:12px;
   letter-spacing:.12em;text-transform:uppercase;color:var(--w60);white-space:nowrap}
 .pv-note{font-size:13px;color:var(--w60);border-left:2px solid var(--w25);padding:10px 14px;margin:16px 0;max-width:64ch}
+.cfg-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(232px,1fr));gap:18px 20px;max-width:840px;margin-top:4px}
+.cfg-f{display:flex;flex-direction:column;gap:7px;min-width:0}
+.cfg-f>label{font-weight:500;font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--w60)}
+.cfg-f input{
+  font-family:'Manrope';font-weight:400;font-size:13px;letter-spacing:.03em;
+  color:var(--w100);background:transparent;
+  border:1px solid var(--w25);padding:14px 12px;
+  min-height:48px;border-radius:0;outline:none;
+  box-sizing:border-box;transition:border-color .16s ease;
+}
+.cfg-f input:focus{border-color:var(--w60)}
+.cfg-f input::placeholder{color:var(--w35)}
+.cfg-f .hint{font-size:12px;color:var(--w35);line-height:1.4}
+.cfg-toggles{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:8px;max-width:840px;margin-top:14px}
+.cfg-save{display:flex;align-items:center;gap:16px;flex-wrap:wrap;margin-top:22px;max-width:840px}
+.cfg-save button{min-height:48px;padding:0 30px}
+.cfg-msg{font-size:13px;color:var(--w60)}
+.cfg-msg.bad{color:var(--warn,#e5534b)}
+.cfg-msg.good{color:var(--w100)}
+.cfg-toggles button[disabled].on{background:transparent;color:var(--w60);border-color:var(--w12);font-weight:400}
 .proc{display:grid;grid-template-columns:1fr auto;gap:14px;padding:9px 0;
   border-bottom:1px solid var(--w06);font-size:14px}
 .proc .p-name{color:var(--w80);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -675,6 +695,10 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
       <div class="btns"><button id="privtoggle" onclick="togglePrivacy()">Show privacy panel</button></div>
     </div>
 
+    <div class="set"><div class="lbl">Home Assistant</div>
+      <div class="btns"><button id="mqtttoggle" onclick="toggleMqtt()">MQTT settings</button></div>
+    </div>
+
     <div class="set"><div class="lbl">Power</div>
       <div class="btns">
         <button id="poff" onclick="pw('powerOff')">Power off</button>
@@ -739,6 +763,84 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
     <button id="adblock-toggle" onclick="toggleAdBlock()">Enable ad blocker</button>
   </div>
   </details>
+</section>
+
+<section class="priv" id="mqttpane" hidden>
+  <div class="lbl">MQTT &amp; Home Assistant</div>
+
+  <div class="pv-h">Broker</div>
+  <div class="pv-sub">Where this TV publishes its telemetry. Home Assistant picks the
+    entities up automatically once the broker is reachable.</div>
+
+  <div class="cfg-grid">
+    <div class="cfg-f">
+      <label for="cfg-host">Broker address</label>
+      <input type="text" id="cfg-host" placeholder="192.168.1.10" autocomplete="off" spellcheck="false">
+      <div class="hint">Hostname or IP of the MQTT broker.</div>
+    </div>
+    <div class="cfg-f">
+      <label for="cfg-port">Port</label>
+      <input type="number" id="cfg-port" placeholder="auto" min="1" max="65535" autocomplete="off">
+      <div class="hint">Left blank: 1883, or 8883 with TLS.</div>
+    </div>
+    <div class="cfg-f">
+      <label for="cfg-user">Username</label>
+      <input type="text" id="cfg-user" autocomplete="off" spellcheck="false">
+      <div class="hint">Blank for an anonymous broker.</div>
+    </div>
+    <div class="cfg-f">
+      <label for="cfg-pass">Password</label>
+      <input type="password" id="cfg-pass" autocomplete="new-password">
+      <div class="hint" id="cfg-pass-hint">Stored on the TV in plain text.</div>
+    </div>
+  </div>
+
+  <div class="cfg-toggles">
+    <button id="cfg-enabled" onclick="cfgToggle('cfg-enabled')">MQTT bridge</button>
+    <button id="cfg-tls" onclick="cfgToggle('cfg-tls')">TLS</button>
+    <button id="cfg-verify" onclick="cfgToggle('cfg-verify')">Verify certificate</button>
+  </div>
+  <div class="pv-note">Without TLS the username and password cross the network in
+    cleartext. The config file is readable by anything with root on this TV, so use a
+    broker account restricted to these topics rather than a shared one.</div>
+
+  <div class="pv-h">Topics &amp; identity</div>
+  <div class="pv-sub">Changing the device ID orphans any entities Home Assistant has
+    already created &mdash; it appears as a second device rather than renaming the first.</div>
+
+  <div class="cfg-grid">
+    <div class="cfg-f">
+      <label for="cfg-prefix">Topic prefix</label>
+      <input type="text" id="cfg-prefix" placeholder="lgtv" autocomplete="off" spellcheck="false">
+      <div class="hint">Must differ per TV. Publishes to &lt;prefix&gt;/telemetry.</div>
+    </div>
+    <div class="cfg-f">
+      <label for="cfg-disc">Discovery prefix</label>
+      <input type="text" id="cfg-disc" placeholder="homeassistant" autocomplete="off" spellcheck="false">
+      <div class="hint">Only change if Home Assistant was reconfigured.</div>
+    </div>
+    <div class="cfg-f">
+      <label for="cfg-devid">Device ID</label>
+      <input type="text" id="cfg-devid" placeholder="lg_tv" autocomplete="off" spellcheck="false">
+      <div class="hint">Lowercase letters, digits and underscores.</div>
+    </div>
+    <div class="cfg-f">
+      <label for="cfg-devname">Device name</label>
+      <input type="text" id="cfg-devname" placeholder="LG OLED TV" autocomplete="off">
+      <div class="hint">Shown as the device name in Home Assistant.</div>
+    </div>
+    <div class="cfg-f">
+      <label for="cfg-interval">Telemetry interval</label>
+      <input type="number" id="cfg-interval" placeholder="10000" min="1000" max="600000" autocomplete="off">
+      <div class="hint">Milliseconds between publishes.</div>
+    </div>
+  </div>
+
+  <div class="cfg-save">
+    <button id="cfg-save-btn" onclick="saveSettings()">Save &amp; restart</button>
+    <span class="cfg-msg" id="cfg-msg">Saving restarts the server. The dashboard reconnects on its own.</span>
+  </div>
+  <div class="sub" id="cfg-file" style="margin-top:14px"></div>
 </section>
 
 <footer>
@@ -1663,6 +1765,126 @@ async function privAction(action) {
     }
   } catch (e) { showErr(e.message); return; }
   setTimeout(loadPrivacy, 800);
+}
+
+// ---- MQTT & Home Assistant settings ----
+let mqttOpen = false, cfgPasswordSet = false;
+
+function toggleMqtt() {
+  mqttOpen = !mqttOpen;
+  q('mqttpane').hidden = !mqttOpen;
+  q('mqtttoggle').textContent = mqttOpen ? 'Hide MQTT settings' : 'MQTT settings';
+  q('mqtttoggle').classList.toggle('on', mqttOpen);
+  if (mqttOpen) { loadSettings(); q('mqttpane').scrollIntoView({ behavior: 'smooth', block: 'start' }); }
+}
+
+function cfgToggle(id) {
+  const b = q(id);
+  b.classList.toggle('on');
+  if (id === 'cfg-tls') cfgSyncTls();
+}
+
+// Certificate verification is meaningless without TLS, so it follows it.
+function cfgSyncTls() {
+  const on = q('cfg-tls').classList.contains('on');
+  q('cfg-verify').disabled = !on;
+}
+
+function cfgMsg(text, kind) {
+  const el = q('cfg-msg');
+  el.textContent = text;
+  el.className = 'cfg-msg' + (kind ? ' ' + kind : '');
+}
+
+async function loadSettings() {
+  try {
+    const r = await fetch(api('/api/settings'));
+    const j = await r.json();
+    if (!j.ok) { cfgMsg(j.error || 'Could not read settings', 'bad'); return; }
+    const m = j.mqtt, d = j.device;
+    q('cfg-host').value = m.host;
+    q('cfg-port').value = m.port == null ? '' : m.port;
+    q('cfg-user').value = m.username;
+    q('cfg-pass').value = '';
+    cfgPasswordSet = m.passwordSet;
+    q('cfg-pass-hint').textContent = cfgPasswordSet
+      ? 'A password is set. Leave blank to keep it.'
+      : 'Stored on the TV in plain text.';
+    q('cfg-prefix').value = m.topicPrefix;
+    q('cfg-disc').value = m.discoveryPrefix;
+    q('cfg-devid').value = d.id;
+    q('cfg-devname').value = d.name;
+    q('cfg-interval').value = m.telemetryIntervalMs;
+    q('cfg-enabled').classList.toggle('on', m.enabled);
+    q('cfg-tls').classList.toggle('on', m.tls);
+    q('cfg-verify').classList.toggle('on', m.tlsRejectUnauthorized);
+    cfgSyncTls();
+    q('cfg-file').textContent = 'Saved to ' + j.configFile + ' on the TV.';
+    q('cfg-save-btn').disabled = !j.writable;
+    cfgMsg(j.writable
+      ? 'Saving restarts the server. The dashboard reconnects on its own.'
+      : 'Controls are disabled in config.json, so settings cannot be changed from here.');
+  } catch (e) { cfgMsg(e.message, 'bad'); }
+}
+
+async function saveSettings() {
+  const body = {
+    mqtt: {
+      enabled: q('cfg-enabled').classList.contains('on'),
+      host: q('cfg-host').value,
+      port: q('cfg-port').value === '' ? null : q('cfg-port').value,
+      tls: q('cfg-tls').classList.contains('on'),
+      tlsRejectUnauthorized: q('cfg-verify').classList.contains('on'),
+      username: q('cfg-user').value,
+      topicPrefix: q('cfg-prefix').value,
+      discoveryPrefix: q('cfg-disc').value,
+      telemetryIntervalMs: q('cfg-interval').value || 10000
+    },
+    device: { id: q('cfg-devid').value, name: q('cfg-devname').value }
+  };
+  // An untouched password field means "keep the stored one", not "clear it".
+  const pass = q('cfg-pass').value;
+  if (pass !== '' || !cfgPasswordSet) body.mqtt.password = pass;
+
+  q('cfg-save-btn').disabled = true;
+  cfgMsg('Saving...');
+  try {
+    const r = await fetch(api('/api/settings'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    });
+    const j = await r.json();
+    if (!j.ok) { cfgMsg(j.error || 'Save failed', 'bad'); q('cfg-save-btn').disabled = false; return; }
+    cfgMsg('Saved. Restarting...');
+    await waitForServer();
+  } catch (e) {
+    cfgMsg(e.message, 'bad');
+    q('cfg-save-btn').disabled = false;
+  }
+}
+
+/*
+ * The restart drops this connection mid-flight, so failures here are expected
+ * until the server is listening again. Give up after ~30s rather than spinning:
+ * a config that stops the server booting needs the log, not another poll.
+ */
+async function waitForServer() {
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, 1000));
+    try {
+      const r = await fetch(api('/api/caps'), { cache: 'no-store' });
+      if (r.ok) {
+        cfgMsg('Applied.', 'good');
+        q('cfg-save-btn').disabled = false;
+        loadSettings();
+        tick();
+        return;
+      }
+    } catch (e) { /* still down */ }
+  }
+  cfgMsg('Saved, but the server did not come back. Check the log on the TV.', 'bad');
+  q('cfg-save-btn').disabled = false;
 }
 
 // Deep link straight to the privacy view: /?privacy=1 . Handy for a bookmark,

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -768,6 +768,14 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
 <section class="priv" id="mqttpane" hidden>
   <div class="lbl">MQTT &amp; Home Assistant</div>
 
+  <div class="pv-row" style="margin-top:12px">
+    <div>
+      <div class="n">Bridge status</div>
+      <div class="d" id="cfg-status-detail">&mdash;</div>
+    </div>
+    <div><span class="pill idle" id="cfg-status-pill">&mdash;</span></div>
+  </div>
+
   <div class="pv-h">Broker</div>
   <div class="pv-sub">Where this TV publishes its telemetry. Home Assistant picks the
     entities up automatically once the broker is reachable.</div>
@@ -1775,6 +1783,7 @@ function toggleMqtt() {
   q('mqttpane').hidden = !mqttOpen;
   q('mqtttoggle').textContent = mqttOpen ? 'Hide MQTT settings' : 'MQTT settings';
   q('mqtttoggle').classList.toggle('on', mqttOpen);
+  cfgPollStatus(mqttOpen);
   if (mqttOpen) { loadSettings(); q('mqttpane').scrollIntoView({ behavior: 'smooth', block: 'start' }); }
 }
 
@@ -1790,6 +1799,63 @@ function cfgSyncTls() {
   q('cfg-verify').disabled = !on;
 }
 
+const CFG_STATE = {
+  connected:  { pill: 'good', label: 'Connected' },
+  connecting: { pill: 'warn', label: 'Connecting' },
+  error:      { pill: 'bad',  label: 'Error' },
+  disabled:   { pill: 'idle', label: 'Off' }
+};
+
+function cfgAge(ms) {
+  if (ms == null) return 'not yet';
+  const s = Math.round(ms / 1000);
+  if (s < 5) return 'just now';
+  if (s < 60) return s + 's ago';
+  if (s < 3600) return Math.round(s / 60) + 'm ago';
+  return Math.round(s / 3600) + 'h ago';
+}
+
+function renderCfgStatus(st) {
+  const meta = CFG_STATE[st.state] || CFG_STATE.disabled;
+  const pill = q('cfg-status-pill');
+  pill.className = 'pill ' + meta.pill;
+  pill.textContent = meta.label;
+
+  const broker = st.broker + (st.tls ? ' over TLS' : '');
+  let text;
+  if (st.state === 'connected') {
+    text = 'Publishing to ' + broker + '. Last telemetry ' + cfgAge(st.lastPublishMs) + '.';
+  } else if (st.state === 'connecting') {
+    text = (st.detail ? st.detail.charAt(0).toUpperCase() + st.detail.slice(1) + '. ' : '') +
+           'Reaching ' + broker + '.';
+  } else if (st.state === 'error') {
+    text = broker + ': ' + st.detail + '. Retrying every 5s.';
+  } else {
+    text = st.detail
+      ? st.detail.charAt(0).toUpperCase() + st.detail.slice(1) + '.'
+      : 'The bridge is off. Nothing is published.';
+  }
+  q('cfg-status-detail').textContent = text;
+}
+
+/*
+ * Only while the pane is open. Saved settings do not take effect until the
+ * restart, so this is also what shows whether the new broker took.
+ */
+let cfgStatusTimer = null;
+function cfgPollStatus(on) {
+  clearInterval(cfgStatusTimer);
+  cfgStatusTimer = on ? setInterval(refreshCfgStatus, 5000) : null;
+}
+
+async function refreshCfgStatus() {
+  try {
+    const r = await fetch(api('/api/settings'), { cache: 'no-store' });
+    const j = await r.json();
+    if (j.ok && j.status) renderCfgStatus(j.status);
+  } catch (e) { /* a restart drops this; the next poll picks it up */ }
+}
+
 function cfgMsg(text, kind) {
   const el = q('cfg-msg');
   el.textContent = text;
@@ -1801,6 +1867,7 @@ async function loadSettings() {
     const r = await fetch(api('/api/settings'));
     const j = await r.json();
     if (!j.ok) { cfgMsg(j.error || 'Could not read settings', 'bad'); return; }
+    if (j.status) renderCfgStatus(j.status);
     const m = j.mqtt, d = j.device;
     q('cfg-host').value = m.host;
     q('cfg-port').value = m.port == null ? '' : m.port;

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -90,9 +90,17 @@ function argvConfigPath() {
   return null;
 }
 
+/*
+ * Where a settings write goes. Set to whichever file loadConfig() actually
+ * read; when none exists yet (a fresh install) it stays at the install path,
+ * so the first save from the dashboard creates the file the boot hook reads.
+ */
+var CONFIG_FILE = '/var/lib/tvweb/config.json';
+
 function loadConfig() {
   var override = argvConfigPath();
   var paths = override ? [override] : ['/var/lib/tvweb/config.json', './config.json'];
+  if (override) CONFIG_FILE = override;
   for (var i = 0; i < paths.length; i++) {
     try {
       if (fs.existsSync(paths[i])) {
@@ -124,6 +132,7 @@ function loadConfig() {
         } catch (e) {
           console.error('warning: could not chmod ' + paths[i] + ': ' + e.message);
         }
+        CONFIG_FILE = paths[i];
         console.log('loaded configuration from ' + paths[i]);
         break;
       }
@@ -2262,6 +2271,118 @@ function send(res, code, body, type) {
   res.end(body);
 }
 
+/*
+ * Settings the dashboard is allowed to write. Everything else in config.json
+ * (port, host, allowControl, allowPower, token) stays file-only: those decide
+ * who may reach this server at all, and a UI that can widen its own exposure
+ * defeats the point of setting them.
+ */
+function readConfigFile() {
+  try {
+    if (fs.existsSync(CONFIG_FILE)) return JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+  } catch (e) {
+    console.error('warning: could not re-read ' + CONFIG_FILE + ': ' + e.message);
+  }
+  return {};
+}
+
+function str(v) { return typeof v === 'string' ? v.trim() : ''; }
+
+/*
+ * A topic segment ends up in every topic this bridge publishes. MQTT wildcards
+ * and a trailing slash would produce topics Home Assistant silently never
+ * matches, which looks like a broken bridge rather than a bad prefix.
+ */
+function badTopic(v) {
+  return !v || /[#+\s]/.test(v) || v.charAt(0) === '/' || v.charAt(v.length - 1) === '/';
+}
+
+function validateSettings(j) {
+  var m = (j && j.mqtt) || {};
+  var d = (j && j.device) || {};
+  var out = { mqtt: {}, device: {} }, e = [];
+
+  out.mqtt.enabled = !!m.enabled;
+  out.mqtt.host = str(m.host);
+  if (out.mqtt.enabled && !out.mqtt.host) e.push('a broker address is required to enable MQTT');
+
+  if (m.port === null || m.port === undefined || m.port === '') {
+    out.mqtt.port = null;
+  } else {
+    var port = parseInt(m.port, 10);
+    if (!(port >= 1 && port <= 65535)) e.push('port must be between 1 and 65535');
+    else out.mqtt.port = port;
+  }
+
+  out.mqtt.tls = !!m.tls;
+  out.mqtt.tlsRejectUnauthorized = m.tlsRejectUnauthorized !== false;
+  out.mqtt.username = str(m.username);
+
+  /*
+   * The password is never sent to the browser, so an absent field means
+   * "unchanged" rather than "clear it". Clearing needs an explicit "".
+   */
+  if (typeof m.password === 'string') out.mqtt.password = m.password;
+
+  out.mqtt.topicPrefix = str(m.topicPrefix) || 'lgtv';
+  if (badTopic(out.mqtt.topicPrefix)) e.push('topic prefix cannot contain +, # or spaces, or start or end with /');
+  out.mqtt.discoveryPrefix = str(m.discoveryPrefix) || 'homeassistant';
+  if (badTopic(out.mqtt.discoveryPrefix)) e.push('discovery prefix cannot contain +, # or spaces, or start or end with /');
+
+  var iv = parseInt(m.telemetryIntervalMs, 10);
+  if (!(iv >= 1000 && iv <= 600000)) e.push('telemetry interval must be between 1000 and 600000 ms');
+  else out.mqtt.telemetryIntervalMs = iv;
+
+  /*
+   * The device id keys every discovery topic and every entity id in Home
+   * Assistant. Changing it orphans the old entities rather than renaming them.
+   */
+  out.device.id = str(d.id);
+  if (!/^[a-z0-9_]{1,64}$/.test(out.device.id)) e.push('device id must be 1-64 characters of a-z, 0-9 or _');
+  out.device.name = str(d.name);
+
+  return { errors: e, value: out };
+}
+
+function writeSettings(patch, cb) {
+  var file = readConfigFile();
+  for (var section in patch) {
+    file[section] = file[section] || {};
+    for (var k in patch[section]) file[section][k] = patch[section][k];
+  }
+  try {
+    var tmp = CONFIG_FILE + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(file, null, 2), 'utf8');
+    fs.chmodSync(tmp, 0600);
+    fs.renameSync(tmp, CONFIG_FILE);   // atomic: never leave a half-written config
+  } catch (err) {
+    return cb(err);
+  }
+  cb(null);
+}
+
+/*
+ * MQTT is wired up once at startup - the client, its keepalive, the telemetry
+ * timer and every discovery topic close over the config that was current then.
+ * Restarting the process is the one way to apply new broker settings that
+ * cannot leave a half-migrated bridge behind.
+ */
+function restartSelf() {
+  var ctl = [path.join(__dirname, 'tvwebctl'), '/var/lib/tvweb/tvwebctl'];
+  for (var i = 0; i < ctl.length; i++) {
+    if (!fs.existsSync(ctl[i])) continue;
+    try {
+      child_process.spawn('/bin/sh', [ctl[i], 'restart'], {
+        detached: true, stdio: 'ignore'
+      }).unref();
+      return true;
+    } catch (e) {
+      console.error('restart failed: ' + e.message);
+    }
+  }
+  return false;
+}
+
 function authed(q) {
   return !CONFIG.token || q.k === CONFIG.token;
 }
@@ -2339,6 +2460,78 @@ var server = http.createServer(function (req, res) {
 
   if (pathname === '/api/stats') {
     return collectStats(function (s) { send(res, 200, JSON.stringify(s)); });
+  }
+
+  if (pathname === '/api/settings' && req.method === 'GET') {
+    if (!authed(u.query)) return send(res, 401, JSON.stringify({ ok: false, error: 'unauthorized' }));
+    var mc = CONFIG.mqtt || {};
+    return send(res, 200, JSON.stringify({
+      ok: true,
+      writable: CONFIG.allowControl,
+      configFile: CONFIG_FILE,
+      mqtt: {
+        enabled: !!mc.enabled,
+        host: mc.host || '',
+        port: mc.port === undefined ? null : mc.port,
+        tls: !!mc.tls,
+        tlsRejectUnauthorized: mc.tlsRejectUnauthorized !== false,
+        username: mc.username || '',
+        // The password is deliberately not returned; only whether one is set.
+        passwordSet: !!mc.password,
+        topicPrefix: mc.topicPrefix || 'lgtv',
+        discoveryPrefix: mc.discoveryPrefix || 'homeassistant',
+        telemetryIntervalMs: mc.telemetryIntervalMs || 10000
+      },
+      device: {
+        id: (CONFIG.device && CONFIG.device.id) || '',
+        name: (CONFIG.device && CONFIG.device.name) || ''
+      }
+    }));
+  }
+
+  if (pathname === '/api/settings' && req.method === 'POST') {
+    if (!authed(u.query)) return send(res, 401, JSON.stringify({ ok: false, error: 'unauthorized' }));
+    if (!CONFIG.allowControl) {
+      return send(res, 403, JSON.stringify({ ok: false, error: 'controls disabled in config' }));
+    }
+    var sctype = String(req.headers['content-type'] || '').toLowerCase();
+    if (sctype.indexOf('application/json') !== 0) {
+      return send(res, 415, JSON.stringify({ ok: false, error: 'Content-Type must be application/json' }));
+    }
+    var sorigin = req.headers.origin;
+    if (sorigin && String(sorigin).replace(/^https?:\/\//, '') !== String(req.headers.host || '')) {
+      return send(res, 403, JSON.stringify({ ok: false, error: 'cross-origin request refused' }));
+    }
+    var sbody = '';
+    req.on('data', function (d) {
+      sbody += d;
+      if (sbody.length > 8192) req.destroy();
+    });
+    req.on('end', function () {
+      var j = null;
+      try { j = JSON.parse(sbody); } catch (e) {
+        return send(res, 400, JSON.stringify({ ok: false, error: 'malformed JSON' }));
+      }
+      var v = validateSettings(j);
+      if (v.errors.length) {
+        return send(res, 400, JSON.stringify({ ok: false, error: v.errors.join('; ') }));
+      }
+      writeSettings(v.value, function (err) {
+        if (err) {
+          return send(res, 500, JSON.stringify({ ok: false, error: 'could not write ' + CONFIG_FILE + ': ' + err.message }));
+        }
+        console.log('settings: saved to ' + CONFIG_FILE + ', restarting to apply');
+        /*
+         * Answer before restarting: the restart kills this process, and the
+         * browser needs the result to know the save itself succeeded.
+         */
+        send(res, 200, JSON.stringify({ ok: true, restarting: true }));
+        setTimeout(function () {
+          if (!restartSelf()) console.error('settings: no tvwebctl found - restart manually to apply');
+        }, 250);
+      });
+    });
+    return;
   }
 
   if (pathname === '/api/control' && req.method === 'POST') {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -27,7 +27,7 @@ var zlib = require('zlib');
  * a link to /releases/tag/v<version>, so a value with no tag behind it gives a
  * 404 rather than a wrong page.
  */
-var TVWEB_VERSION = '0.19.0';
+var TVWEB_VERSION = '0.20.0';
 
 // ---------------------------------------------------------------- config
 var CONFIG = {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -2485,6 +2485,16 @@ var server = http.createServer(function (req, res) {
       device: {
         id: (CONFIG.device && CONFIG.device.id) || '',
         name: (CONFIG.device && CONFIG.device.name) || ''
+      },
+      /* Ages rather than timestamps: the TV's clock is often minutes off the
+         browser's, and a negative "last publish" reads as a fault. */
+      status: {
+        state: MQTT_STATUS.state,
+        broker: MQTT_STATUS.broker,
+        tls: MQTT_STATUS.tls,
+        detail: MQTT_STATUS.detail,
+        forMs: Date.now() - MQTT_STATUS.since,
+        lastPublishMs: MQTT_STATUS.lastPublish ? Date.now() - MQTT_STATUS.lastPublish : null
       }
     }));
   }
@@ -2851,9 +2861,30 @@ function selectState(expr, options) {
   return '{{ (' + expr + ') if (' + expr + ') in [' + quoted.join(', ') + '] else \'None\' }}';
 }
 
+/*
+ * What the dashboard reports about the bridge. The MQTT client is wired up
+ * once at startup against the config as it was then, so this is the only way
+ * to tell whether the broker settings on screen are the ones actually running.
+ */
+var MQTT_STATUS = {
+  state: 'disabled',   // disabled | connecting | connected | error
+  broker: '',
+  tls: false,
+  detail: '',
+  since: Date.now(),
+  lastPublish: 0
+};
+
+function mqttStatus(state, detail) {
+  if (MQTT_STATUS.state !== state) MQTT_STATUS.since = Date.now();
+  MQTT_STATUS.state = state;
+  MQTT_STATUS.detail = detail || '';
+}
+
 function setupHomeAssistant() {
   if (!CONFIG.mqtt || !CONFIG.mqtt.enabled || !CONFIG.mqtt.host) {
     console.log('mqtt: disabled (no host configured)');
+    mqttStatus('disabled', CONFIG.mqtt && CONFIG.mqtt.enabled ? 'no broker address set' : '');
     return;
   }
 
@@ -2893,6 +2924,10 @@ function setupHomeAssistant() {
       retain: true
     }
   });
+
+  MQTT_STATUS.broker = CONFIG.mqtt.host + ':' + mqttClient.opts.port;
+  MQTT_STATUS.tls = useTls;
+  mqttStatus('connecting', '');
 
   function publishDiscovery() {
     var entities = [
@@ -3896,6 +3931,7 @@ function setupHomeAssistant() {
     mqttClient.publish(statusTopic, 'online', true);
     collectStats(function(s) {
       mqttClient.publish(telemetryTopic, JSON.stringify(s), false);
+      MQTT_STATUS.lastPublish = Date.now();
       /*
        * Reconcile the panel switch against what the TV actually reports.
        * It used to be published only when the command arrived over MQTT, so
@@ -3937,6 +3973,7 @@ function setupHomeAssistant() {
   }
 
   mqttClient.on('connect', function() {
+    mqttStatus('connected', '');
     console.log('mqtt: connected to ' + CONFIG.mqtt.host + ':' + mqttClient.opts.port +
                 (useTls ? ' (tls)' : ' (plaintext)'));
     mqttClient.publish(statusTopic, 'online', true);
@@ -4029,7 +4066,14 @@ function setupHomeAssistant() {
   });
 
   mqttClient.on('error', function(err) {
+    mqttStatus('error', err.message);
     console.error('mqtt error:', err.message);
+  });
+
+  /* A socket error destroys the socket, so 'close' follows it. The error text
+     is the part worth reporting, so it stands until the next connect. */
+  mqttClient.on('close', function() {
+    if (MQTT_STATUS.state !== 'error') mqttStatus('connecting', 'connection dropped, retrying');
   });
 
   process.on('SIGTERM', function() {


### PR DESCRIPTION
Two related changes: somewhere to configure MQTT that is not a text editor over SSH, and setup instructions that stop treating MQTT as the point of the project.

**Settings panel.** Broker address, credentials, topic prefix and device identity were only reachable by editing `config.json` over SSH. `GET` and `POST /api/settings` expose the `mqtt` and `device` sections, reached from **MQTT settings** in the controls column.

`port`, `host`, `allowControl`, `allowPower` and `token` stay file-only: they decide who can reach the server, and a UI able to widen its own exposure defeats setting them. Writes go through a temp file and rename so a failure cannot leave a half-written config, and the stored password is never sent to the browser — an empty field means "keep the existing one". Saving restarts the process, since MQTT is wired up once at startup and a restart is the only way to apply broker changes without leaving a half-migrated bridge.

**Setup flow.** Configuring a broker was step 2, before the install, so a reader who wanted only the dashboard — or MQTT without Home Assistant — had nothing to follow. Install now comes first and needs no configuration; MQTT becomes an optional step 3 that explains what MQTT, a broker, Home Assistant and Discovery are before asking for a broker address, and documents the dashboard route, the config-file route, and MQTT without Home Assistant.

The old table marked "dashboard and Home Assistant" as the default; both the shipped defaults and `config.example.json` have `mqtt.enabled` false.

The Security section now records that the panel lets anyone who can reach the port redirect the TV's telemetry on a default install, since that is new exposure.

Verified on the B8 (webOS 4.4.3): save and restart round-trips in ~2s with the other config keys and 0600 permissions preserved; a fresh install with no config file creates one correctly; validation rejects wildcard topic prefixes, bad device ids, out-of-range ports and intervals; and the POST guard rejects cross-site origins along with `Origin: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)