### PR TITLE
Name the two consent flags webOS 9 adds

### DIFF
--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -1951,6 +1951,9 @@ function consentGroup(key) {
  */
 var CONSENT_NAMES = {
   networkAllowed:      'Network use',
+  /* webOS 9 only, and named after the TV's own eulaGroupName for each. */
+  marketingOnAllowed:  'Marketing',
+  shoppingOnAllowed:   'Shopping',
   generalTermsAllowed: 'Terms of Use and Privacy Policy',
   chpAllowed:          'LG Channels',
   acrOnAllowed:        'Screen recognition (master consent)',


### PR DESCRIPTION
`marketingOnAllowed` and `shoppingOnAllowed` exist on a C2 (webOS 9.2.2) and not
on a B8, so they showed as raw keys under "No published description". Named
after the `eulaGroupName` the TV gives each, so neither name is invented.

Names only: they go in `CONSENT_NAMES`, which does not affect whether a flag is
settable. Both were already toggles by virtue of appearing in the licence
mapping, and still are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)