### PR TITLE
Add the OLED65C8PUA to the tested-on table

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ versions and panel types.
 | Model | webOS | Firmware | Panel | Notes |
 | :--- | :--- | :--- | :--- | :--- |
 | OLED65B8SLC | 4.4.3 | 05.50.70 | OLED | Development set |
+| OLED65C8PUA | 4.4.0 | 05.50.15 | OLED | No `getAdid` on this firmware |
 | OLED65C9AUA | 4.9.x (4.5+) | 05.50.00 | OLED | |
 | OLED55C9PLA | 4.9.0 | 05.30.40 | OLED | Working fine |
 | OLED55C1PUB | 6.x (6.3+) | 03.53.45 | OLED | SSH install and MQTT bridge confirmed |


### PR DESCRIPTION
Reported working in #61 on webOS 4.4.0, firmware 05.50.15.

Noted that `getAdid` does not exist on that firmware. It does on 4.4.3, so this
is a 4.4.0 difference rather than a webOS 4 one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)