### PR TITLE
Fix the playback keys, and publish the player state

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A server that runs **on** a rooted LG webOS TV. It serves a live dashboard to
 any browser on the network, and will optionally bridge the TV into Home
-Assistant over MQTT as a single auto-discovered device with up to 65 entities.
+Assistant over MQTT as a single auto-discovered device with up to 68 entities.
 
 The dashboard needs nothing but the TV. 
 
@@ -24,7 +24,7 @@ Four tabs: Control, Metrics, Privacy and MQTT.
 
 ### Home Assistant (Auto-Discovered Device via MQTT)
 
-Up to 65 native entities arrive over MQTT Discovery as a single unified device
+Up to 68 native entities arrive over MQTT Discovery as a single unified device
 <p align="center">
   <a href="https://github.com/user-attachments/assets/1d76b1a2-68d9-42a4-a497-b107d706b235"><img width="800" alt="Home Assistant MQTT entities" src="https://github.com/user-attachments/assets/1d76b1a2-68d9-42a4-a497-b107d706b235" /></a>
 </p>
@@ -81,7 +81,7 @@ and firmware updates use.
    dashboard. Includes an on-TV blocker for LG's ad and telemetry
    endpoints, and a switch for the two diagnostics services that upload to LG.
    
-3. **Integrating the TV into Home Assistant.** Optional, over MQTT: up to 65
+3. **Integrating the TV into Home Assistant.** Optional, over MQTT: up to 68
    entities arrive as a single auto-discovered device &mdash; no YAML, no LG
    account &mdash; so the TV can be automated and its telemetry recorded
    alongside everything else in the house.
@@ -374,7 +374,7 @@ Full detail, including the MQTT ACL guidance and optional TLS, is in
 ## Documentation
 
 * [docs/SECURITY.md](docs/SECURITY.md) &mdash; threat model, SSH migration, MQTT hardening
-* [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) &mdash; up to 65 entities, universal media player, example automations
+* [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) &mdash; up to 68 entities, universal media player, example automations
 * [docs/IMPLEMENTATION.md](docs/IMPLEMENTATION.md) &mdash; architecture, `/proc/lg` reference, platform quirks
 
 ---

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A server that runs **on** a rooted LG webOS TV. It serves a live dashboard to
 any browser on the network, and will optionally bridge the TV into Home
-Assistant over MQTT as a single auto-discovered device with up to 61 entities.
+Assistant over MQTT as a single auto-discovered device with up to 65 entities.
 
 The dashboard needs nothing but the TV. 
 
@@ -24,7 +24,7 @@ Four tabs: Control, Metrics, Privacy and MQTT.
 
 ### Home Assistant (Auto-Discovered Device via MQTT)
 
-Up to 61 native entities arrive over MQTT Discovery as a single unified device
+Up to 65 native entities arrive over MQTT Discovery as a single unified device
 <p align="center">
   <a href="https://github.com/user-attachments/assets/1d76b1a2-68d9-42a4-a497-b107d706b235"><img width="800" alt="Home Assistant MQTT entities" src="https://github.com/user-attachments/assets/1d76b1a2-68d9-42a4-a497-b107d706b235" /></a>
 </p>
@@ -81,7 +81,7 @@ and firmware updates use.
    dashboard. Includes an on-TV blocker for LG's ad and telemetry
    endpoints, and a switch for the two diagnostics services that upload to LG.
    
-3. **Integrating the TV into Home Assistant.** Optional, over MQTT: up to 61
+3. **Integrating the TV into Home Assistant.** Optional, over MQTT: up to 65
    entities arrive as a single auto-discovered device &mdash; no YAML, no LG
    account &mdash; so the TV can be automated and its telemetry recorded
    alongside everything else in the house.
@@ -374,7 +374,7 @@ Full detail, including the MQTT ACL guidance and optional TLS, is in
 ## Documentation
 
 * [docs/SECURITY.md](docs/SECURITY.md) &mdash; threat model, SSH migration, MQTT hardening
-* [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) &mdash; up to 61 entities, universal media player, example automations
+* [docs/HOME-ASSISTANT.md](docs/HOME-ASSISTANT.md) &mdash; up to 65 entities, universal media player, example automations
 * [docs/IMPLEMENTATION.md](docs/IMPLEMENTATION.md) &mdash; architecture, `/proc/lg` reference, platform quirks
 
 ---

--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -6,7 +6,7 @@ Entity reference and example automations.
 
 ## Entities
 
-Once connected to your MQTT broker, Home Assistant automatically discovers **up to 61 native entities** under a single unified device:
+Once connected to your MQTT broker, Home Assistant automatically discovers **up to 65 native entities** under a single unified device:
 
 ### Controls & Switches
 | Domain | Entity ID | Name | Description |

--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -92,7 +92,7 @@ Playback reaches an HDMI source over CEC, where the TV has only one key for both
 | `sensor` | `sensor.lg_tv_flash_health` | Flash Storage Health | eMMC remaining health estimate (`>90% (Healthy)`) |
 | `sensor` | `sensor.lg_tv_flash_wear` | Flash Wear Level | JEDEC write-cycle consumption (`0–10%`) |
 | `sensor` | `sensor.lg_tv_uptime` | Uptime | TV uptime in seconds |
-| `sensor` | `sensor.lg_tv_tvweb_version` | TVWeb Version | Version of tvweb itself, not TV firmware (diagnostic) |
+| `sensor` | `sensor.lg_tv_tvweb_version` | Server Version | Version of this server, not TV firmware (diagnostic) |
 
 ---
 

--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -6,7 +6,7 @@ Entity reference and example automations.
 
 ## Entities
 
-Once connected to your MQTT broker, Home Assistant automatically discovers **up to 65 native entities** under a single unified device:
+Once connected to your MQTT broker, Home Assistant automatically discovers **up to 68 native entities** under a single unified device:
 
 ### Controls & Switches
 | Domain | Entity ID | Name | Description |
@@ -31,6 +31,8 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **up 
 | `text` | `text.lg_tv_screen_notification` | Screen Notification | Send custom toast messages to TV screen |
 | `button` | `button.lg_tv_restart` | Restart TV | Reboots the TV (requires `allowPower: true`) |
 | `button` | `button.lg_tv_power_off` | Power Off TV | Powers off the TV (requires `allowPower: true`) |
+
+Playback reaches an HDMI source over CEC, where the TV has only one key for both halves of play/pause. Pause and Play / Pause behave as expected there; Play toggles rather than only resuming. On the built-in apps all four are exact.
 
 ### OLED Panel Health (OLED sets only)
 | Domain | Entity ID | Name | Description |
@@ -67,6 +69,7 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **up 
 | `sensor` | `sensor.lg_tv_panel_dimming` | Panel Dimming | Dynamic backlight/panel dimming state |
 | `sensor` | `sensor.lg_tv_audio_output` | Audio Output | Audio scenario (e.g. *Optical / Headphone*, *Internal*) |
 | `sensor` | `sensor.lg_tv_active_app` | Active App | Current foreground app or friendly CEC device |
+| `sensor` | `sensor.lg_tv_play_state` | Player State | State of the TV's own media pipeline (`playing`, `paused`, `stopped`) |
 
 ### Hardware, Remote & System Diagnostics
 | Domain | Entity ID | Name | Description |

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -1008,11 +1008,18 @@ function setAdBlock(mode, cb) {
   }
 }
 
+/*
+ * KEY_PLAY toggles: on a B8 feeding an Apple TV it starts and stops playback,
+ * while KEY_PLAYPAUSE and KEY_PAUSECD do nothing at all - webOS forwards this
+ * one over CEC and not the others. So the play/pause control sends 207, and
+ * the separate play and pause entities are gone rather than published dead.
+ * The names stay accepted for anything calling /api/control directly.
+ */
 var RCU_KEY_CODES = {
   play: 207,
-  pause: 201,
-  playPause: 164,
-  playpause: 164,
+  pause: 207,
+  playPause: 207,
+  playpause: 207,
   stop: 128,
   fastForward: 208,
   fastforward: 208,
@@ -1509,10 +1516,13 @@ function collectStats(cb) {
           mode: (snd && snd.settings && snd.settings.soundMode) || 'standard'
         };
         /*
-         * Whether something is actually playing. applicationManager says which
-         * app is in front; this is a different service, reporting the media
-         * pipeline behind it, which is the part Home Assistant wants. Asked for
-         * on r/homeassistant, endpoint included.
+         * The TV's own media pipeline. applicationManager says which app is in
+         * front; this says what that app's player is doing.
+         *
+         * It describes the TV, not the source: with an external input it reads
+         * "playing" for as long as the HDMI pipeline is up, whatever the box on
+         * the other end is doing. Useful for the built-in apps, not a transport
+         * state for anything on HDMI.
          */
         lunaCached('com.webos.service.acb/getForegroundAppInfo', {}, 4000, function (acb) {
         var pipe = (acb && Array.isArray(acb.acbs)) ? acb.acbs[0] : null;
@@ -3492,7 +3502,21 @@ function setupHomeAssistant() {
   MQTT_STATUS.tls = useTls;
   mqttStatus('connecting', '');
 
+  /*
+   * Entities this once published and no longer does. Home Assistant keeps a
+   * discovered entity until its config topic is cleared, so without this an
+   * upgrade leaves the retired ones sitting in the device forever.
+   */
+  var RETIRED_ENTITIES = [
+    { type: 'button', id: 'play' },     // folded into play_pause: KEY_PLAY toggles
+    { type: 'button', id: 'pause' }     // KEY_PAUSECD did nothing on any set tested
+  ];
+
   function publishDiscovery() {
+    for (var r = 0; r < RETIRED_ENTITIES.length; r++) {
+      mqttClient.publish(discPfx + '/' + RETIRED_ENTITIES[r].type + '/' + devId + '/' +
+                         RETIRED_ENTITIES[r].id + '/config', '', true);
+    }
     var entities = [
       {
         type: 'sensor', id: 'soc_temperature',
@@ -3603,11 +3627,12 @@ function setupHomeAssistant() {
       {
         type: 'sensor', id: 'play_state',
         payload: {
-          name: 'Play State',
+          name: 'Player State',
           state_topic: telemetryTopic,
           // Absent on a set whose media service does not answer, rather than
           // reported as stopped - nothing playing and nothing to ask are
-          // different things.
+          // different things. On an external input this tracks the HDMI
+          // pipeline rather than the source's own transport state.
           value_template: '{{ value_json.media.state if value_json.media else None }}',
           icon: 'mdi:play-pause'
         }
@@ -4188,24 +4213,6 @@ function setupHomeAssistant() {
           payload_on: 'ON',
           payload_off: 'OFF',
           icon: 'mdi:shield-check'
-        }
-      },
-      {
-        type: 'button', id: 'play',
-        payload: {
-          name: 'Play',
-          command_topic: pfx + '/command/playback',
-          payload_press: 'play',
-          icon: 'mdi:play'
-        }
-      },
-      {
-        type: 'button', id: 'pause',
-        payload: {
-          name: 'Pause',
-          command_topic: pfx + '/command/playback',
-          payload_press: 'pause',
-          icon: 'mdi:pause'
         }
       },
       {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -3516,18 +3516,7 @@ function setupHomeAssistant() {
   MQTT_STATUS.tls = useTls;
   mqttStatus('connecting', '');
 
-  /*
-   * Entities this once published and no longer does. Home Assistant keeps a
-   * discovered entity until its config topic is cleared, so without this an
-   * upgrade leaves the retired ones sitting in the device forever.
-   */
-  var RETIRED_ENTITIES = [];
-
   function publishDiscovery() {
-    for (var r = 0; r < RETIRED_ENTITIES.length; r++) {
-      mqttClient.publish(discPfx + '/' + RETIRED_ENTITIES[r].type + '/' + devId + '/' +
-                         RETIRED_ENTITIES[r].id + '/config', '', true);
-    }
     var entities = [
       {
         type: 'sensor', id: 'soc_temperature',

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -27,7 +27,7 @@ var zlib = require('zlib');
  * a link to /releases/tag/v<version>, so a value with no tag behind it gives a
  * 404 rather than a wrong page.
  */
-var TVWEB_VERSION = '0.27.0';
+var TVWEB_VERSION = '0.28.0';
 
 // ---------------------------------------------------------------- config
 var CONFIG = {
@@ -3779,14 +3779,15 @@ function setupHomeAssistant() {
       },
       {
         /*
-         * tvweb's own version, not the TV's - the device's sw_version already
-         * carries the firmware. Named for the program so the two cannot be
-         * read as each other on a device page that shows both. Diagnostic: it
-         * belongs beside the firmware, not among the readings.
+         * This server's own version, not the TV's - the device's sw_version
+         * already carries the firmware. The id stays tvweb_version: it is the
+         * unique_id an existing install is already discovered under, and
+         * changing it would orphan that entity and register a second one.
+         * Diagnostic: it belongs beside the firmware, not among the readings.
          */
         type: 'sensor', id: 'tvweb_version',
         payload: {
-          name: 'TVWeb Version',
+          name: 'Server Version',
           state_topic: telemetryTopic,
           value_template: '{{ value_json.tvwebVersion }}',
           entity_category: 'diagnostic',

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -1009,24 +1009,38 @@ function setAdBlock(mode, cb) {
 }
 
 /*
- * KEY_PLAY toggles: on a B8 feeding an Apple TV it starts and stops playback,
- * while KEY_PLAYPAUSE and KEY_PAUSECD do nothing at all - webOS forwards this
- * one over CEC and not the others. So the play/pause control sends 207, and
- * the separate play and pause entities are gone rather than published dead.
- * The names stay accepted for anything calling /api/control directly.
+ * Measured on a B8 against the built-in player, watching playStateNow move:
+ * KEY_PAUSE pauses, KEY_PLAY resumes, and KEY_PLAYPAUSE, KEY_PAUSECD and
+ * KEY_PLAYCD do nothing at all. Pause was previously sent as KEY_PAUSECD,
+ * which is why it never worked.
+ *
+ * Over CEC to an external box, KEY_PLAY behaves as a toggle instead.
  */
 var RCU_KEY_CODES = {
   play: 207,
-  pause: 207,
-  playPause: 207,
-  playpause: 207,
+  pause: 119,
   stop: 128,
   fastForward: 208,
   fastforward: 208,
   rewind: 168
 };
 
+/*
+ * No key toggles the built-in player, so this asks what it is doing and sends
+ * the other one. An external input reports "playing" whatever the box on the
+ * end is doing, and KEY_PLAY is a toggle over CEC, so that path just sends it.
+ */
+function sendPlayPause(cb) {
+  luna('com.webos.service.acb/getForegroundAppInfo', {}, function (acb) {
+    var pipe = (acb && Array.isArray(acb.acbs)) ? acb.acbs[0] : null;
+    var external = !pipe || pipe.playerType === 'external input';
+    var paused = !!(pipe && String(pipe.playStateNow) === 'paused');
+    sendMediaKey(external || paused ? 'play' : 'pause', cb);
+  });
+}
+
 function sendMediaKey(cmd, cb) {
+  if (cmd === 'playPause' || cmd === 'playpause') return sendPlayPause(cb);
   var code = RCU_KEY_CODES[cmd];
   if (!code) {
     if (cb) cb(false);
@@ -3507,10 +3521,7 @@ function setupHomeAssistant() {
    * discovered entity until its config topic is cleared, so without this an
    * upgrade leaves the retired ones sitting in the device forever.
    */
-  var RETIRED_ENTITIES = [
-    { type: 'button', id: 'play' },     // folded into play_pause: KEY_PLAY toggles
-    { type: 'button', id: 'pause' }     // KEY_PAUSECD did nothing on any set tested
-  ];
+  var RETIRED_ENTITIES = [];
 
   function publishDiscovery() {
     for (var r = 0; r < RETIRED_ENTITIES.length; r++) {
@@ -4213,6 +4224,24 @@ function setupHomeAssistant() {
           payload_on: 'ON',
           payload_off: 'OFF',
           icon: 'mdi:shield-check'
+        }
+      },
+      {
+        type: 'button', id: 'play',
+        payload: {
+          name: 'Play',
+          command_topic: pfx + '/command/playback',
+          payload_press: 'play',
+          icon: 'mdi:play'
+        }
+      },
+      {
+        type: 'button', id: 'pause',
+        payload: {
+          name: 'Pause',
+          command_topic: pfx + '/command/playback',
+          payload_press: 'pause',
+          icon: 'mdi:pause'
         }
       },
       {

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -1508,6 +1508,21 @@ function collectStats(cb) {
           output_raw: rawSnd,
           mode: (snd && snd.settings && snd.settings.soundMode) || 'standard'
         };
+        /*
+         * Whether something is actually playing. applicationManager says which
+         * app is in front; this is a different service, reporting the media
+         * pipeline behind it, which is the part Home Assistant wants. Asked for
+         * on r/homeassistant, endpoint included.
+         */
+        lunaCached('com.webos.service.acb/getForegroundAppInfo', {}, 4000, function (acb) {
+        var pipe = (acb && Array.isArray(acb.acbs)) ? acb.acbs[0] : null;
+        if (pipe && pipe.playStateNow) {
+          out.media = {
+            state: String(pipe.playStateNow),
+            playerType: pipe.playerType || null,
+            fullScreen: pipe.isFullScreen !== false
+          };
+        }
         lunaCached('com.webos.applicationManager/getForegroundAppInfo', {}, 4000, function (app) {
           if (app && app.appId) {
             var shortApp = String(app.appId).replace('com.webos.app.', '');
@@ -1564,6 +1579,7 @@ function collectStats(cb) {
               });
             }
           );
+        });
         });
       }
     );
@@ -3582,6 +3598,18 @@ function setupHomeAssistant() {
           state_topic: telemetryTopic,
           value_template: '{{ value_json.display_title or value_json.app_name or value_json.app }}',
           icon: 'mdi:television-play'
+        }
+      },
+      {
+        type: 'sensor', id: 'play_state',
+        payload: {
+          name: 'Play State',
+          state_topic: telemetryTopic,
+          // Absent on a set whose media service does not answer, rather than
+          // reported as stopped - nothing playing and nothing to ask are
+          // different things.
+          value_template: '{{ value_json.media.state if value_json.media else None }}',
+          icon: 'mdi:play-pause'
         }
       },
       {


### PR DESCRIPTION
Pause was sent as `KEY_PAUSECD` and play/pause as `KEY_PLAYPAUSE`; neither
key does anything on a webOS TV, so both controls were silently dead. Pause
now sends `KEY_PAUSE`, and play/pause asks the media service what the player
is doing and sends the other key, because nothing on the remote toggles.

An HDMI source is reached over CEC, where `KEY_PLAY` is itself a toggle and
the pipeline reports "playing" regardless of what the box on the end is doing.
Pause and play/pause are correct there; Play toggles rather than only
resuming, which is documented rather than worked around.

Adds a Player State sensor from the same service, describing the TV's own
pipeline. Entity count corrected to 68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)