### PR TITLE
Make screen shift and logo dimming settable

### DIFF
--- a/docs/HOME-ASSISTANT.md
+++ b/docs/HOME-ASSISTANT.md
@@ -27,6 +27,8 @@ Once connected to your MQTT broker, Home Assistant automatically discovers **up 
 | `button` | `button.lg_tv_pause` | Pause | Pause media playback |
 | `button` | `button.lg_tv_play_pause` | Play / Pause | Toggle media playback |
 | `button` | `button.lg_tv_stop` | Stop | Stop media playback |
+| `switch` | `switch.lg_tv_oled_screen_shift` | OLED Screen Shift | Pixel orbiting, on OLED sets |
+| `select` | `select.lg_tv_oled_logo_dimming` | OLED Logo Dimming | Local logo dimming: Off, Light, High |
 | `button` | `button.lg_tv_screensaver` | Start Screensaver | Immediately trigger webOS screensaver |
 | `text` | `text.lg_tv_screen_notification` | Screen Notification | Send custom toast messages to TV screen |
 | `button` | `button.lg_tv_restart` | Restart TV | Reboots the TV (requires `allowPower: true`) |
@@ -49,8 +51,6 @@ Playback reaches an HDMI source over CEC, where the TV has only one key for both
 | `sensor` | `sensor.lg_tv_oled_failure_alerts` | OLED Compensation Failures | Total compensation failure alerts recorded on set |
 | `binary_sensor` | `binary_sensor.lg_tv_oled_asbl_dimmer` | OLED ASBL Protection | State of Auto Static Brightness Limiter / GSR dimmer |
 | `binary_sensor` | `binary_sensor.lg_tv_screen_saver_active` | Screen Saver | Whether a screen saver is on screen now; withheld on sets that do not report it |
-| `sensor` | `sensor.lg_tv_oled_screen_shift` | OLED Screen Shift | Pixel orbiting state (`ON` / `OFF`) |
-| `sensor` | `sensor.lg_tv_oled_logo_dimming` | OLED Logo Dimming | Logo luminance reduction (`Low`, `Strong`, `Off`) |
 
 ### HDMI 2.1 & Live Stream Telemetry
 | Domain | Entity ID | Name | Description |

--- a/server/assets/ui.html
+++ b/server/assets/ui.html
@@ -577,14 +577,14 @@ footer{margin-top:38px;font-size:12px;letter-spacing:.10em;text-transform:upperc
               <div class="prot-title">Screen Shift <span class="prot-sub">&middot; Pixel Orbiting</span></div>
               <div class="prot-desc">Subtly shifts the entire picture by micro-increments over time to disperse static edge wear</div>
             </div>
-            <div class="prot-status"><span class="pill" id="shift-pill">&mdash;</span></div>
+            <div class="prot-status"><button class="pill" id="shift-pill" onclick="toggleScreenShift()" title="Switch pixel orbiting on or off">&mdash;</button></div>
           </div>
           <div class="prot-row" id="logo-row" hidden>
             <div class="prot-main">
               <div class="prot-title">Adjust Logo Brightness <span class="prot-sub">&middot; Local Logo Dimming</span></div>
               <div class="prot-desc">Selectively dims only static logo/HUD pixels locally while preserving full brightness for the rest of the picture</div>
             </div>
-            <div class="prot-status"><span class="pill" id="logo-pill">&mdash;</span></div>
+            <div class="prot-status"><button class="pill" id="logo-pill" onclick="cycleLogoDimming()" title="Cycle Off, Light, High">&mdash;</button></div>
           </div>
         </div>
       </details>
@@ -1389,6 +1389,7 @@ async function tick() {
       q('shift-row').hidden = false;
       const pill = q('shift-pill');
       const on = /on/i.test(o.screen_shift);
+      shiftNow = on ? 'on' : 'off';
       pill.textContent = on ? 'On' : 'Off';
       pill.className = 'pill ' + (on ? 'good' : 'idle');
       hasProt = true;
@@ -1400,6 +1401,7 @@ async function tick() {
       q('logo-row').hidden = false;
       const pill = q('logo-pill');
       const val = String(o.logo_dimming).toLowerCase();
+      logoNow = val;
       let label = val.charAt(0).toUpperCase() + val.slice(1);
       if (val === 'strong') label = 'High';
       pill.textContent = label;
@@ -1560,6 +1562,19 @@ async function c(action, value) {
     setTimeout(tick, 320);
     return j;
   } catch (e) { showErr(e.message); }
+}
+/*
+ * The two settable panel protections. Both read back from the next poll, so
+ * neither writes its own label - the state stays the TV's to report.
+ */
+let shiftNow = null, logoNow = null;
+function toggleScreenShift() {
+  c('screenShift', shiftNow === 'on' ? 'off' : 'on');
+}
+function cycleLogoDimming() {
+  const order = ['off', 'light', 'strong'];
+  const next = order[(order.indexOf(logoNow) + 1) % order.length];
+  c('logoDimming', next);
 }
 function toggleLight(which) {
   const el = q(which === 'standbyLight' ? 'lt_standby' : 'lt_logo');

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -2475,6 +2475,10 @@ function detectLogoLight(cb) {
 
 var SLEEP_TIMER_VALUES = ['off', '10', '30', '60', '90', '120'];
 
+// What the settings service accepts for logoLuminanceAdjust, per
+// getSystemSettingValues on a B8. "strong" is the strongest, not an on/off.
+var LOGO_DIMMING_VALUES = ['off', 'light', 'strong'];
+
 function doControl(action, value, cb) {
   if (!CONFIG.allowControl) return cb({ ok: false, error: 'controls disabled in config' });
 
@@ -2674,6 +2678,28 @@ function doControl(action, value, cb) {
                   function (r) { lastStats = null; cb({ ok: !!(r && r.returnValue) }); });
 
     // Front panel LEDs. Both live in the "option" category.
+    /*
+     * Both live in the picture category and are OLED panel protections, not
+     * picture settings: screenShift takes on/off, logoLuminanceAdjust takes
+     * off/light/strong. The settings service publishes the accepted values
+     * through getSystemSettingValues, and a rejected one returns false rather
+     * than erroring, so an unsupported value simply does not take.
+     */
+    case 'screenShift':
+      var shiftOn = (value === true || value === 'on' || value === 'ON' || value === 'true');
+      return luna('com.webos.service.settings/setSystemSettings',
+                  { category: 'picture', settings: { screenShift: shiftOn ? 'on' : 'off' } },
+                  function (r) { lastStats = null; cb({ ok: !!(r && r.returnValue) }); });
+
+    case 'logoDimming':
+      var logoVal = String(value || '').trim().toLowerCase();
+      if (LOGO_DIMMING_VALUES.indexOf(logoVal) === -1) {
+        return cb({ ok: false, error: 'logo dimming takes ' + LOGO_DIMMING_VALUES.join(', ') });
+      }
+      return luna('com.webos.service.settings/setSystemSettings',
+                  { category: 'picture', settings: { logoLuminanceAdjust: logoVal } },
+                  function (r) { lastStats = null; cb({ ok: !!(r && r.returnValue) }); });
+
     case 'standbyLight':
     case 'logoLight':
       var lightKey = (action === 'standbyLight') ? 'standByLight' : 'logoLight';
@@ -3546,7 +3572,22 @@ function setupHomeAssistant() {
   MQTT_STATUS.tls = useTls;
   mqttStatus('connecting', '');
 
+  /*
+   * Entities published under a different component than they are now. Home
+   * Assistant keys a discovered entity on its config topic, so a sensor that
+   * became a switch is not replaced by the switch - it is left behind, still
+   * holding the last value it was sent.
+   */
+  var RETIRED_ENTITIES = [
+    { type: 'sensor', id: 'oled_screen_shift' },
+    { type: 'sensor', id: 'oled_logo_dimming' }
+  ];
+
   function publishDiscovery() {
+    for (var r = 0; r < RETIRED_ENTITIES.length; r++) {
+      mqttClient.publish(discPfx + '/' + RETIRED_ENTITIES[r].type + '/' + devId + '/' +
+                         RETIRED_ENTITIES[r].id + '/config', '', true);
+    }
     var entities = [
       {
         type: 'sensor', id: 'soc_temperature',
@@ -4014,20 +4055,35 @@ function setupHomeAssistant() {
         }
       },
       {
-        type: 'sensor', id: 'oled_screen_shift',
+        /*
+         * Both of these are settings rather than readings, so they carry their
+         * own state and need no separate sensor. The panel protections beside
+         * them - ASBL, GSR - are hardware behaviour and stay read-only.
+         */
+        type: 'switch', id: 'oled_screen_shift',
         payload: {
           name: 'OLED Screen Shift',
+          command_topic: pfx + '/command/screenShift',
           state_topic: telemetryTopic,
-          value_template: '{{ value_json.oled.screen_shift if value_json.oled else "Unknown" }}',
+          value_template: '{{ ("ON" if value_json.oled.screen_shift == "on" else "OFF") if value_json.oled and value_json.oled.screen_shift else none }}',
+          payload_on: 'on',
+          payload_off: 'off',
+          state_on: 'ON',
+          state_off: 'OFF',
           icon: 'mdi:arrow-all'
         }
       },
       {
-        type: 'sensor', id: 'oled_logo_dimming',
+        type: 'select', id: 'oled_logo_dimming',
         payload: {
           name: 'OLED Logo Dimming',
+          command_topic: pfx + '/command/logoDimming',
           state_topic: telemetryTopic,
-          value_template: '{{ value_json.oled.logo_dimming if value_json.oled else "Unknown" }}',
+          // LG calls the strongest setting "strong"; the TV's own menu shows it
+          // as High, and so does the dashboard.
+          options: ['Off', 'Light', 'High'],
+          command_template: '{{ {"Off":"off","Light":"light","High":"strong"}[value] }}',
+          value_template: '{{ {"off":"Off","light":"Light","strong":"High"}.get(value_json.oled.logo_dimming, "Off") if value_json.oled and value_json.oled.logo_dimming else none }}',
           icon: 'mdi:television-guide'
         }
       },


### PR DESCRIPTION
Both are picture-category settings rather than readings, and the settings
service takes writes to them - `screenShift` accepts on/off, and
`logoLuminanceAdjust` accepts off, light or strong, which is what
`getSystemSettingValues` reports for the key. The panel showed them as pills
and could not change them; Home Assistant had them as sensors.

They become a switch and a select, which carry their own state, so the two
read-only sensors are retired and their config topics cleared - a sensor that
becomes a switch is otherwise left behind in Home Assistant, still holding the
last value it was sent. Anything referencing `sensor.lg_tv_oled_screen_shift`
or `sensor.lg_tv_oled_logo_dimming` needs to move to the new entity.

On the dashboard the two pills answer to a click: screen shift toggles, and
logo dimming cycles Off, Light, High. ASBL and GSR sit in the same section and
stay read-only - those are hardware behaviour, not settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)