### PR TITLE
Bump version to 0.29.0

### DIFF
--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -27,7 +27,7 @@ var zlib = require('zlib');
  * a link to /releases/tag/v<version>, so a value with no tag behind it gives a
  * 404 rather than a wrong page.
  */
-var TVWEB_VERSION = '0.28.1';
+var TVWEB_VERSION = '0.29.0';
 
 // ---------------------------------------------------------------- config
 var CONFIG = {


### PR DESCRIPTION
Releases the panel protection controls in #79. A minor rather than a patch:
two entities change component, so anything referencing the old sensors needs
repointing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)