### PR TITLE
Control the panel protections on webOS 4 as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ There are no dependencies. This is ES5 on the Node 0.12 runtime that is on the T
    and failure alerts.
 
 7. **Controlling the OLED burn-in protections.** What each one does and a switch
-   for it: screen shift and logo dimming on any OLED, and on sets that carry
-   LG's panel service, ASBL and Global Stress Reduction &mdash; the two normally
-   reachable only from the TV's service menu, with a service remote and a PIN.
+   for it: screen shift and logo dimming on any OLED, and on sets that expose
+   them, ASBL and Global Stress Reduction &mdash; the two normally reachable only
+   from the TV's service menu, with a service remote and a PIN.
 
 8. **Opening the service menu, and unlocking it where it is locked.** LG's own
    engineering menu, put on the TV screen from a browser &mdash; no service
@@ -103,9 +103,8 @@ default.
 
 The OLED Care tab, or `/?tab=oledcare`, on OLED sets. What each burn-in
 protection does and a switch for it: screen shift and logo dimming on any OLED,
-and on sets carrying LG's panel service, ASBL and Global Stress Reduction &mdash;
-the two normally reachable only from the TV's service menu, with a service
-remote and a PIN.
+and ASBL and Global Stress Reduction &mdash; the two normally
+reachable only from the TV's service menu, with a service remote and a PIN.
 
 <p align="center">
   <a href="docs/screenshots/oledcare.png"><img src="docs/screenshots/oledcare.png" alt="OLED Care tab: screen shift, logo dimming, temporal peak control and global stress reduction, each described, with switches and a warranty warning" width="700"></a>
@@ -160,9 +159,9 @@ and firmware updates use.
   remote, and unlocks the full version on firmware that ships it cut down. The
   unlock needs a power cycle; sets that do not lock it say so.
 * **OLED Care tab.** What each burn-in protection does, and a switch for it.
-  Screen shift and logo dimming on any OLED; on sets that carry LG's panel
-  service, temporal peak control and global stress reduction too - the two
-  normally reachable only from the service menu, with a warning to match.
+  Screen shift and logo dimming on any OLED; temporal peak control and global
+  stress reduction too, on webOS 4 and webOS 9 alike - the two normally
+  reachable only from the service menu, with a warning to match.
 * **HDMI 2.1 diagnostics.** Link rate, chroma format, HDCP version, cable error
   counter, ALLM, VRR, QMS, and colorimetry. Requires `/proc/lg/hdmi20`.
 * **Magic Remote & hardware info.** Battery, model, firmware; SoC architecture,

--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -1237,16 +1237,41 @@ function openServiceMenu(which, cb) {
 }
 
 var OLED_EPL = 'com.webos.service.oledepl';
-var oledEplSupported = null;   // null = not yet asked
+var OLED_SYSPROP = 'com.webos.service.tv.systemproperty';
+// null = not yet asked, false = neither service answers.
+var oledProtVia = null;
 
-function readOledProtections(cb) {
-  luna(OLED_EPL + '/getGlobalStressReduction', {}, function (gsr) {
-    if (!gsr || gsr.returnValue !== true) {
-      oledEplSupported = false;
+function oledProtControllable() {
+  return oledProtVia === 'epl' || oledProtVia === 'sysprop';
+}
+
+/*
+ * webOS 4 keeps the same two protections behind a different service, with the
+ * values as the strings "true" and "false" - a B8 answers getProperties for
+ * OledTPC and OledGSR and has no oledepl at all. Its own service menu reads
+ * them from there, which is how this was found.
+ */
+function readViaSysprop(cb) {
+  luna(OLED_SYSPROP + '/getProperties', { keys: ['OledTPC', 'OledGSR'] }, function (r) {
+    if (!r || r.returnValue !== true || typeof r.OledTPC === 'undefined') {
+      oledProtVia = false;
       return cb(null);
     }
+    oledProtVia = 'sysprop';
+    cb({
+      gsr: String(r.OledGSR) === 'true',
+      tpc: String(r.OledTPC) === 'true',
+      gsrStressCount: null
+    });
+  });
+}
+
+function readOledProtections(cb) {
+  if (oledProtVia === 'sysprop') return readViaSysprop(cb);
+  luna(OLED_EPL + '/getGlobalStressReduction', {}, function (gsr) {
+    if (!gsr || gsr.returnValue !== true) return readViaSysprop(cb);
     luna(OLED_EPL + '/getTemporalPeakControl', {}, function (tpc) {
-      oledEplSupported = true;
+      oledProtVia = 'epl';
       cb({
         gsr: gsr.enable === true,
         gsrStressCount: (typeof gsr.stressCount === 'number') ? gsr.stressCount : null,
@@ -1257,10 +1282,11 @@ function readOledProtections(cb) {
 }
 
 function setOledProtection(which, enabled, cb) {
-  var method = (which === 'gsr') ? 'setGlobalStressReduction'
-             : (which === 'tpc') ? 'setTemporalPeakControl' : null;
-  if (!method) return cb({ ok: false, error: 'unknown protection: ' + which });
-  luna(OLED_EPL + '/' + method, { enable: !!enabled }, function (r) {
+  if (which !== 'gsr' && which !== 'tpc') {
+    return cb({ ok: false, error: 'unknown protection: ' + which });
+  }
+
+  function afterWrite(r) {
     lastStats = null;
     cachedOled = null;
     if (!r || r.returnValue !== true) {
@@ -1272,6 +1298,20 @@ function setOledProtection(which, enabled, cb) {
       cb({ ok: now === !!enabled, state: state,
            error: now === !!enabled ? undefined : 'the setting did not take' });
     });
+  }
+
+  // Ask first, so a set before any read still goes to the right service.
+  readOledProtections(function () {
+    if (oledProtVia === 'sysprop') {
+      var prop = {};
+      prop[which === 'gsr' ? 'OledGSR' : 'OledTPC'] = enabled ? 'true' : 'false';
+      return luna(OLED_SYSPROP + '/setProperties', prop, afterWrite);
+    }
+    if (oledProtVia !== 'epl') {
+      return cb({ ok: false, error: 'this TV does not offer the control' });
+    }
+    var method = (which === 'gsr') ? 'setGlobalStressReduction' : 'setTemporalPeakControl';
+    luna(OLED_EPL + '/' + method, { enable: !!enabled }, afterWrite);
   });
 }
 
@@ -3634,7 +3674,7 @@ var server = http.createServer(function (req, res) {
           ok: true,
           isOled: !!st.oled,
           // Whether this set has the service the service menu goes through.
-          serviceControls: oledEplSupported === true,
+          serviceControls: oledProtControllable(),
           writable: CONFIG.allowControl,
           /*
            * null where the set says nothing. Without the service, all there is


### PR DESCRIPTION
A B8 was told its temporal peak control and global stress reduction were "not
adjustable on this TV". That was wrong.

webOS 4 keeps the same two behind `com.webos.service.tv.systemproperty`, as the
strings `"true"` and `"false"` under `OledTPC` and `OledGSR`. Its own service
menu reads them from there - `OLEDController.qml` on a B8 calls
`getProperties`/`setProperties`, where a C2 calls `oledepl`. Neither service
exists on the other firmware, so each is tried in turn and the answer
remembered.

Measured on a B8: both read `true`, and temporal peak control goes to `false`
and back through the dashboard, with `getProperties` agreeing at every step.

This is the firmware where these are most worth having - the 2021-and-older
sets never got LG's ASBL fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)