### PR TITLE
Bump version to 0.33.1

### DIFF
--- a/server/tvweb.js
+++ b/server/tvweb.js
@@ -27,7 +27,7 @@ var zlib = require('zlib');
  * a link to /releases/tag/v<version>, so a value with no tag behind it gives a
  * 404 rather than a wrong page.
  */
-var TVWEB_VERSION = '0.33.0';
+var TVWEB_VERSION = '0.33.1';
 
 // ---------------------------------------------------------------- config
 var CONFIG = {


### PR DESCRIPTION
Releases the webOS 4 panel protection fix in #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)